### PR TITLE
Deprecate region flag and determine from zone.

### DIFF
--- a/kubetest2-tf/go.mod
+++ b/kubetest2-tf/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/IBM/ibm-cos-sdk-go v1.12.1
 	github.com/octago/sflags v0.3.1
 	github.com/pkg/errors v0.9.1
+	github.com/ppc64le-cloud/powervs-utils v0.0.0-20241128062007-a2c048c7bcde
 	github.com/spf13/pflag v1.0.6
 	k8s.io/client-go v0.32.2
 	k8s.io/cluster-bootstrap v0.32.2

--- a/kubetest2-tf/go.sum
+++ b/kubetest2-tf/go.sum
@@ -600,6 +600,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b h1:0LFwY6Q3gMACTjAbMZBjXAqTOzOwFaj2Ld6cjeQ7Rig=
 github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/ppc64le-cloud/powervs-utils v0.0.0-20241128062007-a2c048c7bcde h1:2D/4d2nnEiEz2O6vFhgnvVFUJXEZEPkBlVURaMxDgUA=
+github.com/ppc64le-cloud/powervs-utils v0.0.0-20241128062007-a2c048c7bcde/go.mod h1:yfr6HHPYyJzVgnivMsobLMbHQqUHrzcIqWM4Nav4kc8=
 github.com/prometheus/client_golang v1.20.2 h1:5ctymQzZlyOON1666svgwn3s6IKWgfbjsejTMiXIyjg=
 github.com/prometheus/client_golang v1.20.2/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/kubetest2-tf/pkg/providers/powervs/powervs.go
+++ b/kubetest2-tf/pkg/providers/powervs/powervs.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 
+	pvsutils "github.com/ppc64le-cloud/powervs-utils"
 	"github.com/spf13/pflag"
 
 	"sigs.k8s.io/provider-ibmcloud-test-infra/kubetest2-tf/pkg/providers"
@@ -41,6 +42,7 @@ func (p *Provider) BindFlags(flags *pflag.FlagSet) {
 	flags.StringVar(
 		&p.Apikey, "powervs-api-key", "", "IBM Cloud API Key used for accessing the APIs",
 	)
+	// TODO: Deprecate the flag powervs-region at a later point in time.
 	flags.StringVar(
 		&p.Region, "powervs-region", "", "IBM Cloud PowerVS region name",
 	)
@@ -65,6 +67,12 @@ func (p *Provider) BindFlags(flags *pflag.FlagSet) {
 	flags.StringVar(
 		&p.SSHKey, "powervs-ssh-key", "", "PowerVS SSH Key to authenticate LPARs",
 	)
+	flags.MarkDeprecated("powervs-region", "Region will now be auto-identified from zone.")
+	flags.Parse(os.Args)
+	// If the value has not been set through the flag, determine through the util func using zone.
+	if p.Region == "" {
+		p.Region = pvsutils.RegionFromZone(p.Zone)
+	}
 }
 
 func (p *Provider) DumpConfig(dir string) error {


### PR DESCRIPTION
This PR introduces deprecation for the `powervs-region` flag as the PowerVS Region can be determined from Zone.

```
[root@kubetest2-tf1 provider-ibmcloud-test-infra]# kubetest2 tf --powervs-dns k8s-tests --powervs-image-name CentOS-Stream-9....
....
....
Flag --powervs-region has been deprecated, Region will now be auto-identified from zone.
```
