### PR TITLE
Include CentOS environments for disabling selinux

### DIFF
--- a/kubetest2-tf/data/k8s-ansible/roles/disable-swap-selinux/tasks/main.yml
+++ b/kubetest2-tf/data/k8s-ansible/roles/disable-swap-selinux/tasks/main.yml
@@ -12,4 +12,4 @@
   ansible.posix.selinux:
     state: permissive
     policy: targeted
-  when:  ansible_distribution == "RedHat"
+  when: ansible_distribution in ['RedHat', 'CentOS']


### PR DESCRIPTION
Observing errors related to `permission denied` in AVC messages for kubelet as a result of selinux enforced in the VM.
```
type=SYSCALL msg=audit(1742402741.557:1949): arch=c0000015 syscall=286 success=no exit=-13 a0=ffffffffffffff9c a1=10007d0d670 a2=541 a3=1a4 items=0 ppid=1 pid=79178 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="(kubelet)" exe="/usr/lib/systemd/systemd" subj=system_u:system_r:init_t:s0 key=(null)
```

Mitigated by disabling selinux on CentOS environments.