### PR TITLE
HEART_BEAT_PID to cleanup and change default reosurce type

### DIFF
--- a/hack/boskos.sh
+++ b/hack/boskos.sh
@@ -19,9 +19,9 @@ set -o nounset
 set -o pipefail
 
 USER=${USER:-"k8s-prow-job"}
-RESOURCE_TYPE=${RESOURCE_TYPE:-"powervs-k8s-conformance"}
+RESOURCE_TYPE=${RESOURCE_TYPE:-"powervs"}
 
-trap cleanup EXIT
+trap 'cleanup ${HEART_BEAT_PID:-}' EXIT
 
 release_account(){
     url="http://${BOSKOS_HOST}/release?name=${BOSKOS_RESOURCE_NAME}&dest=dirty&owner=${USER}"


### PR DESCRIPTION
- Missed sending `HEART_BEAT_PID` to cleanup 
- Adding default resource type to `powervs` to match with https://github.com/kubernetes/k8s.io/blob/main/kubernetes/ibm-ppc64le/prow/boskos-resources-configmap.yaml#L13