### PR TITLE
Add feature-gates to kubelet, apiserver, scheduler, controller

### DIFF
--- a/kubetest2-tf/data/k8s-ansible/roles/install-k8s/templates/kubeadm.yaml.j2
+++ b/kubetest2-tf/data/k8s-ansible/roles/install-k8s/templates/kubeadm.yaml.j2
@@ -18,6 +18,9 @@ nodeRegistration:
 {% endif %}
   kubeletExtraArgs:
     cgroup-driver: {{ cgroup_driver }}
+{% if (feature_gates is defined) %}
+    feature-gates: {{ feature_gates }}
+{% endif %}
 ---
 apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration
@@ -30,6 +33,11 @@ kubernetesVersion: "{{ release_marker }}"
 controlPlaneEndpoint: "{{ loadbalancer }}:{{ apiserver_port }}"
 {% endif %}
 apiServer:
+{% if (feature_gates is defined) and (runtime_config is defined) %}
+  extraArgs:
+    feature-gates: {{ feature_gates }}
+    runtime-config: {{ runtime_config }}
+{% endif %}
   timeoutForControlPlane: 4m0s
 {% if (extra_cert is defined) and extra_cert %}
   certSANs:
@@ -43,13 +51,22 @@ apiServer:
 controllerManager:
   extraArgs:
     bind-address: "0.0.0.0"
+{% if (feature_gates is defined) %}
+    feature-gates: {{ feature_gates }}
+{% endif %}
 scheduler:
   extraArgs:
     bind-address: "0.0.0.0"
+{% if (feature_gates is defined) %}
+    feature-gates: {{ feature_gates }}
+{% endif %}
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 cgroupDriver: {{ cgroup_driver }}
+{% if (feature_gates is defined) %}
+feature-gates: {{ feature_gates }}
+{% endif %}
 {% if (runtime is defined) and 'containerd' == runtime %}
 containerRuntimeEndpoint: "unix:///run/containerd/containerd.sock"
 {% elif (runtime is defined) and 'crio' == runtime %}
@@ -66,6 +83,10 @@ discovery:
   tlsBootstrapToken: {{ bootstrap_token }}
 kind: JoinConfiguration
 nodeRegistration:
+{% if (feature_gates is defined) %}
+  kubeletExtraArgs:
+    feature-gates: {{ feature_gates }}
+{% endif %}
 {% if (runtime is defined) and 'containerd' == runtime %}
   criSocket: "unix:///run/containerd/containerd.sock"
 {% elif (runtime is defined) and 'crio' == runtime %}


### PR DESCRIPTION
This is required for jobs like [ci-kubernetes-e2e-gci-gce-alpha-enabled-default](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml#L908) and [ci-kubernetes-e2e-ec2-alpha-enabled-default](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cloud-provider/periodic-e2e.yaml#L104) for IBM's `ppc64le`

Similar to https://github.com/kubernetes-sigs/provider-aws-test-infra/pull/292
https://github.com/kubernetes-sigs/provider-aws-test-infra/pull/293
https://github.com/kubernetes-sigs/provider-aws-test-infra/pull/310