### PR TITLE
Fix kubeadm config templation

### DIFF
--- a/kubetest2-tf/data/k8s-ansible/roles/install-k8s/templates/kubeadm.yaml.j2
+++ b/kubetest2-tf/data/k8s-ansible/roles/install-k8s/templates/kubeadm.yaml.j2
@@ -21,7 +21,7 @@ nodeRegistration:
       value: {{ cgroup_driver }}
 {% if (feature_gates is defined) %}
     - name: feature-gates
-      value: "{{ feature_gates | join(',') }}"
+      value: "{{ feature_gates }}"
 {% endif %}
 timeouts:
   controlPlaneComponentHealthCheck: 4m0s
@@ -41,7 +41,7 @@ apiServer:
 {% if (feature_gates is defined) and (runtime_config is defined) %}
   extraArgs:
     - name: feature-gates
-      value: "{{ feature_gates | join(',') }}"
+      value: "{{ feature_gates }}"
     - name: runtime-config
       value: {{ runtime_config }}
 {% endif %}
@@ -60,7 +60,7 @@ controllerManager:
       value: "0.0.0.0"
 {% if feature_gates is defined %}
     - name: feature-gates
-      value: "{{ feature_gates | join(',') }}"
+      value: "{{ feature_gates }}"
 {% endif %}
 scheduler:
   extraArgs:
@@ -68,7 +68,7 @@ scheduler:
       value: "0.0.0.0"
 {% if feature_gates is defined %}
     - name: feature-gates
-      value: "{{ feature_gates | join(',') }}"
+      value: "{{ feature_gates }}"
 {% endif %}
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
@@ -76,7 +76,7 @@ kind: KubeletConfiguration
 cgroupDriver: {{ cgroup_driver }}
 {% if feature_gates is defined %}
 featureGates:
-{%   for feature in feature_gates %}
+{%   for feature in feature_gates.split(',') %}
   {{ feature | replace("=", ": ") }}
 {%   endfor %}
 {% endif %}
@@ -96,10 +96,6 @@ discovery:
     unsafeSkipCAVerification: true
   tlsBootstrapToken: {{ bootstrap_token }}
 nodeRegistration:
-{% if (feature_gates is defined) %}
-  kubeletExtraArgs:
-    feature-gates: "{{ feature_gates | join(',') }}"
-{% endif %}
 {% if (runtime is defined) and 'containerd' == runtime %}
   criSocket: "unix:///run/containerd/containerd.sock"
 {% elif (runtime is defined) and 'crio' == runtime %}


### PR DESCRIPTION
The existing templation has an issue wherein, the passed parameters are accepted as a string, rather than an array, causing tokenisation of individual characters of the `feature_gates` variable. The current approach simplifies by accepting the series of flags as a string, and then parsing them. It now requires to be passed as 
`--extra-vars=feature_gates:AllAlpha=true,EventedPLEG=false`

Sample kubelet.conf with the rendered flags:
```
crashLoopBackOff: {}
evictionPressureTransitionPeriod: 0s
featureGates:
  AllAlpha: true <---
  EventedPLEG: false <---
fileCheckFrequency: 0s
```
API-server config: 
```
      --bind-address=0.0.0.0
      --feature-gates=AllAlpha=true,EventedPLEG=false
      --kubeconfig=/etc/kubernetes/scheduler.conf
```

cc @Rajalakshmi-Girish. 