### PR TITLE
Introduce tasks to patch OS with latest updates

### DIFF
--- a/kubetest2-tf/data/k8s-ansible/patch-nodes.yaml
+++ b/kubetest2-tf/data/k8s-ansible/patch-nodes.yaml
@@ -1,0 +1,15 @@
+- name: Update nodes with latest patches and updates
+  hosts:
+    - masters
+    - workers
+  roles:
+    - role: update-node-os
+
+- name: Reboot Kubernetes nodes one-by-one
+  hosts:
+    - masters
+    - workers
+  serial: 1
+  become: yes
+  roles:
+    - role: reboot-sequentially

--- a/kubetest2-tf/data/k8s-ansible/roles/reboot-sequentially/tasks/main.yaml
+++ b/kubetest2-tf/data/k8s-ansible/roles/reboot-sequentially/tasks/main.yaml
@@ -1,0 +1,61 @@
+- block:
+    - name: Resolve Kubernetes node name from inventory IP
+      shell: |
+        kubectl get nodes -o jsonpath="{range .items[*]}{.metadata.name} {.status.addresses[?(@.type=='InternalIP')].address}{'\n'}{end}" --kubeconfig {{ kubeconfig_path }} |\
+        grep {{ inventory_hostname }} | awk '{print $1}'
+      register: node_name
+      delegate_to: "{{ groups['masters'][0] }}"
+
+    - name: Cordon the kubernetes node
+      shell: |
+        kubectl cordon {{ node_name.stdout }}
+      register: drain_output
+      changed_when: "'already cordoned' not in drain_output.stdout"
+      delegate_to: "{{ groups['masters'][0] }}"
+
+    - name: Check and wait if there are any running jobs that need to complete before draining.
+      shell: |
+        kubectl get pods -n test-pods \
+        --kubeconfig {{ kubeconfig_path }} \
+        --field-selector spec.nodeName={{ node_name.stdout }},status.phase=Running \
+        -o go-template={% raw %}'{{range .items}}{{if or (not .metadata.ownerReferences) (ne (index .metadata.ownerReferences 0).kind "DaemonSet")}}{{.metadata.name}}{{"\n"}} {{end}}{{end}}'{% endraw %} \
+        | wc -l
+      register: running_pod_count
+      retries: 360
+      delay: 30
+      until: running_pod_count.stdout | int == 0
+      delegate_to: "{{ groups['masters'][0] }}"
+
+    - name: Drain Kubernetes Node
+      shell: |
+        kubectl drain {{ node_name.stdout }} --ignore-daemonsets --delete-emptydir-data --kubeconfig {{ kubeconfig_path }}
+      register: drain_output
+      changed_when: "'already cordoned' not in drain_output.stdout"
+      delegate_to: "{{ groups['masters'][0] }}"
+
+    - name: Wait for all pods to be evicted
+      shell: |
+        kubectl get pods -n test-pods --field-selector spec.nodeName={{ node_name.stdout }},status.phase=Running -o go-template='{% raw %}{{range .items}}{{if or (not .metadata.ownerReferences) (ne (index .metadata.ownerReferences 0).kind "DaemonSet")}}{{.metadata.name}}{{"\\n"}}{{end}}{{end}}{% endraw %}' | wc -l
+      register: pods_remaining
+      until: pods_remaining.stdout | int == 0
+      retries: 10
+      delay: 15
+      delegate_to: "{{ groups['masters'][0] }}"
+
+    - name: Reboot node
+      reboot:
+
+    - name: Wait for node to become Ready
+      shell: |
+        kubectl get node {{ node_name.stdout }} --kubeconfig {{ kubeconfig_path }} -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+      register: node_status
+      until: node_status.stdout == "True"
+      retries: 20
+      delay: 15
+      delegate_to: "{{ groups['masters'][0] }}"
+
+    - name: Uncordon the node
+      shell: kubectl uncordon {{ node_name.stdout }} --kubeconfig {{ kubeconfig_path }}
+      delegate_to: "{{ groups['masters'][0] }}"
+
+  when: reboot_check is defined and reboot_check.rc == 1

--- a/kubetest2-tf/data/k8s-ansible/roles/update-node-os/tasks/main.yaml
+++ b/kubetest2-tf/data/k8s-ansible/roles/update-node-os/tasks/main.yaml
@@ -1,0 +1,11 @@
+- name: Update packages and kernel to latest available versions
+  package:
+    name: '*'
+    state: latest
+  when: ansible_pkg_mgr in ['yum', 'dnf']
+
+- name: Check if reboot required
+  shell: needs-restarting -r
+  register: reboot_check
+  ignore_errors: yes
+  when: ansible_distribution in ['CentOS', 'RedHat']


### PR DESCRIPTION
This utillity playbook performs the tasks of performing updates at the OS level, which includes package or kernel level updates.
Initial state where Kernel version is 5.14.0-312.el9.ppc64le 
```
root@p10-image-builder ~]# kubectl get nodes -A -o wide
NAME           STATUS   ROLES           AGE    VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE          KERNEL-VERSION           CONTAINER-RUNTIME
kishen-k8s-1   Ready    control-plane   4h5m   v1.31.2   10.20.177.48    <none>        CentOS Stream 9   5.14.0-312.el9.ppc64le   containerd://1.7.13
kishen-k8s-2   Ready    control-plane   4h5m   v1.31.2   10.20.177.40    <none>        CentOS Stream 9   5.14.0-312.el9.ppc64le   containerd://1.7.13
kishen-k8s-3   Ready    control-plane   4h5m   v1.31.2   10.20.177.89    <none>        CentOS Stream 9   5.14.0-312.el9.ppc64le   containerd://1.7.13
kishen-k8s-4   Ready    <none>          4h5m   v1.31.2   10.20.177.141   <none>        CentOS Stream 9   5.14.0-312.el9.ppc64le   containerd://1.7.13
kishen-k8s-5   Ready    <none>          4h5m   v1.31.2   10.20.177.110   <none>        CentOS Stream 9   5.14.0-312.el9.ppc64le   containerd://1.7.13
```
Once the playbook starts executing:
```
root@p10-image-builder ~]# kubectl get nodes -o wide
NAME           STATUS                     ROLES           AGE    VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE          KERNEL-VERSION           CONTAINER-RUNTIME
kishen-k8s-1   Ready,SchedulingDisabled   control-plane   5h9m   v1.31.2   10.20.177.48    <none>        CentOS Stream 9   5.14.0-312.el9.ppc64le   containerd://1.7.13
kishen-k8s-2   Ready                      control-plane   5h9m   v1.31.2   10.20.177.40    <none>        CentOS Stream 9   5.14.0-312.el9.ppc64le   containerd://1.7.13
kishen-k8s-3   Ready                      control-plane   5h9m   v1.31.2   10.20.177.89    <none>        CentOS Stream 9   5.14.0-312.el9.ppc64le   containerd://1.7.13
kishen-k8s-4   Ready                      <none>          5h9m   v1.31.2   10.20.177.141   <none>        CentOS Stream 9   5.14.0-312.el9.ppc64le   containerd://1.7.13
kishen-k8s-5   Ready                      <none>          5h8m   v1.31.2   10.20.177.110   <none>        CentOS Stream 9   5.14.0-312.el9.ppc64le   containerd://1.7.13


[root@p10-image-builder ~]# kubectl get nodes -o wide
NAME           STATUS                        ROLES           AGE     VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE          KERNEL-VERSION           CONTAINER-RUNTIME
kishen-k8s-1   Ready                         control-plane   5h14m   v1.31.2   10.20.177.48    <none>        CentOS Stream 9   5.14.0-578.el9.ppc64le   containerd://1.7.13
kishen-k8s-2   NotReady,SchedulingDisabled   control-plane   5h13m   v1.31.2   10.20.177.40    <none>        CentOS Stream 9   5.14.0-312.el9.ppc64le   containerd://1.7.13
kishen-k8s-3   Ready                         control-plane   5h13m   v1.31.2   10.20.177.89    <none>        CentOS Stream 9   5.14.0-312.el9.ppc64le   containerd://1.7.13
kishen-k8s-4   Ready                         <none>          5h13m   v1.31.2   10.20.177.141   <none>        CentOS Stream 9   5.14.0-312.el9.ppc64le   containerd://1.7.13
kishen-k8s-5   Ready                         <none>          5h13m   v1.31.2   10.20.177.110   <none>        CentOS Stream 9   5.14.0-312.el9.ppc64le   containerd://1.7.13


[root@p10-image-builder ~]# kubectl get nodes -o wide
NAME           STATUS                     ROLES           AGE     VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE          KERNEL-VERSION           CONTAINER-RUNTIME
kishen-k8s-1   Ready                      control-plane   5h15m   v1.31.2   10.20.177.48    <none>        CentOS Stream 9   5.14.0-578.el9.ppc64le   containerd://1.7.13
kishen-k8s-2   Ready                      control-plane   5h15m   v1.31.2   10.20.177.40    <none>        CentOS Stream 9   5.14.0-578.el9.ppc64le   containerd://1.7.13
kishen-k8s-3   Ready,SchedulingDisabled   control-plane   5h15m   v1.31.2   10.20.177.89    <none>        CentOS Stream 9   5.14.0-312.el9.ppc64le   containerd://1.7.13
kishen-k8s-4   Ready                      <none>          5h15m   v1.31.2   10.20.177.141   <none>        CentOS Stream 9   5.14.0-312.el9.ppc64le   containerd://1.7.13
kishen-k8s-5   Ready                      <none>          5h15m   v1.31.2   10.20.177.110   <none>        CentOS Stream 9   5.14.0-312.el9.ppc64le   containerd://1.7.13

Until all nodes are updated... 
[root@p10-image-builder ~]# kubectl get nodes -o wide
NAME           STATUS   ROLES           AGE     VERSION   INTERNAL-IP     EXTERNAL-IP   OS-IMAGE          KERNEL-VERSION           CONTAINER-RUNTIME
kishen-k8s-1   Ready    control-plane   6h10m   v1.31.2   10.20.177.48    <none>        CentOS Stream 9   5.14.0-578.el9.ppc64le   containerd://1.7.13
kishen-k8s-2   Ready    control-plane   6h10m   v1.31.2   10.20.177.40    <none>        CentOS Stream 9   5.14.0-578.el9.ppc64le   containerd://1.7.13
kishen-k8s-3   Ready    control-plane   6h10m   v1.31.2   10.20.177.89    <none>        CentOS Stream 9   5.14.0-578.el9.ppc64le   containerd://1.7.13
kishen-k8s-4   Ready    <none>          6h9m    v1.31.2   10.20.177.141   <none>        CentOS Stream 9   5.14.0-578.el9.ppc64le   containerd://1.7.13
kishen-k8s-5   Ready    <none>          6h9m    v1.31.2   10.20.177.110   <none>        CentOS Stream 9   5.14.0-578.el9.ppc64le   containerd://1.7.13
```
If there's a prow-job running in the test-pods namespace, the playbook has a retry mechanism for 3h(The max that can take for the job to finish) before performing a reboot. This was mimiced using a dummy pod in test-pods namespace and validating the same.
```
TASK [reboot-sequentially : Check and wait if there are any running jobs that need to complete before draining.] *****************************************************
FAILED - RETRYING: [10.20.177.141 -> 10.20.177.48]: Check and wait if there are any running jobs that need to complete before draining. (360 retries left).
FAILED - RETRYING: [10.20.177.141 -> 10.20.177.48]: Check and wait if there are any running jobs that need to complete before draining. (359 retries left).
FAILED - RETRYING: [10.20.177.141 -> 10.20.177.48]: Check and wait if there are any running jobs that need to complete before draining. (358 retries left).
FAILED - RETRYING: [10.20.177.141 -> 10.20.177.48]: Check and wait if there are any running jobs that need to complete before draining. (357 retries left).
FAILED - RETRYING: [10.20.177.141 -> 10.20.177.48]: Check and wait if there are any running jobs that need to complete before draining. (356 retries left).
FAILED - RETRYING: [10.20.177.141 -> 10.20.177.48]: Check and wait if there are any running jobs that need to complete before draining. (355 retries left).
FAILED - RETRYING: [10.20.177.141 -> 10.20.177.48]: Check and wait if there are any running jobs that need to complete before draining. (354 retries left).
FAILED - RETRYING: [10.20.177.141 -> 10.20.177.48]: Check and wait if there are any running jobs that need to complete before draining. (353 retries left).
FAILED - RETRYING: [10.20.177.141 -> 10.20.177.48]: Check and wait if there are any running jobs that need to complete before draining. (352 retries left).
changed: [10.20.177.141 -> 10.20.177.48]
```

```
NAMESPACE     NAME                                      READY   STATUS    RESTARTS      AGE
kube-system   calico-kube-controllers-868cbf9cc-lf6cv   1/1     Running   0             25m
kube-system   calico-node-pcxwq                         1/1     Running   1 (62m ago)   6h13m
kube-system   calico-node-t2f4m                         1/1     Running   1 (55m ago)   6h13m
kube-system   calico-node-t7dxp                         1/1     Running   1 (26m ago)   6h13m
kube-system   calico-node-vq9b2                         1/1     Running   1 (22m ago)   6h13m
kube-system   calico-node-xh94c                         1/1     Running   1 (59m ago)   6h13m
kube-system   coredns-7c65d6cfc9-2n627                  1/1     Running   0             25m
kube-system   coredns-7c65d6cfc9-n4r7p                  1/1     Running   0             28m
kube-system   etcd-kishen-k8s-1                         1/1     Running   1 (62m ago)   6h13m
kube-system   etcd-kishen-k8s-2                         1/1     Running   1 (59m ago)   6h13m
kube-system   etcd-kishen-k8s-3                         1/1     Running   1 (55m ago)   6h13m
kube-system   kube-apiserver-kishen-k8s-1               1/1     Running   1 (62m ago)   6h13m
kube-system   kube-apiserver-kishen-k8s-2               1/1     Running   1 (59m ago)   6h13m
kube-system   kube-apiserver-kishen-k8s-3               1/1     Running   1 (55m ago)   6h13m
kube-system   kube-controller-manager-kishen-k8s-1      1/1     Running   1 (62m ago)   6h13m
kube-system   kube-controller-manager-kishen-k8s-2      1/1     Running   1 (59m ago)   6h13m
kube-system   kube-controller-manager-kishen-k8s-3      1/1     Running   1 (55m ago)   6h13m
kube-system   kube-proxy-4cg8f                          1/1     Running   1 (62m ago)   6h13m
kube-system   kube-proxy-b9tv5                          1/1     Running   1 (55m ago)   6h13m
kube-system   kube-proxy-jdwn8                          1/1     Running   1 (59m ago)   6h13m
kube-system   kube-proxy-x2kk6                          1/1     Running   1 (26m ago)   6h13m
kube-system   kube-proxy-ztk94                          1/1     Running   1 (22m ago)   6h13m
kube-system   kube-scheduler-kishen-k8s-1               1/1     Running   1 (62m ago)   6h13m
kube-system   kube-scheduler-kishen-k8s-2               1/1     Running   1 (59m ago)   6h13m
kube-system   kube-scheduler-kishen-k8s-3               1/1     Running   1 (55m ago)   6h13m
```