### PR TITLE
Introduce ignore_preflight_errors flag for kubeadm

### DIFF
--- a/kubetest2-tf/data/k8s-ansible/group_vars/all
+++ b/kubetest2-tf/data/k8s-ansible/group_vars/all
@@ -47,6 +47,7 @@ release_marker: ci/latest
 bootstrap_token: abcdef.0123456789abcdef
 kubelet_extra_args: ""
 k8s_branch: master
+ignore_preflight_errors: "SystemVerification"
 
 # in the format of: https://dl.k8s.io/{{ directory }}/{{ build_version }}/kubernetes-client-linux-ppc64le.tar.gz
 # Eg: https://dl.k8s.io/ci/v1.28.0-alpha.1.48+039ae1edf5a71f/kubernetes-client-linux-ppc64le.tar.gz

--- a/kubetest2-tf/data/k8s-ansible/roles/install-k8s/tasks/main.yml
+++ b/kubetest2-tf/data/k8s-ansible/roles/install-k8s/tasks/main.yml
@@ -60,11 +60,9 @@
 
 - name: Perform kubeadm init on the control plane node based on LB configuration.
   command: >
-    {% if loadbalancer == '' -%}
-      kubeadm init --config /root/kubeadm.yaml
-    {%- else -%}
-      kubeadm init --config /root/kubeadm.yaml --upload-certs
-    {%- endif %}
+    kubeadm init --config /root/kubeadm.yaml
+    {% if loadbalancer != '' %} --upload-certs{% endif %}
+    {% if ignore_preflight_errors != '' %} --ignore-preflight-errors={{ ignore_preflight_errors }}{% endif %}
   when: inventory_hostname == groups['masters'][0]
 
 
@@ -88,7 +86,9 @@
   with_items: "{{ groups['all'] }}"
 
 - name: kubeadm join control plane nodes
-  command: "{{ kubernetes_cp_join_command }}"
+  command: >
+      {{ kubernetes_cp_join_command }}
+      {% if ignore_preflight_errors != '' %} --ignore-preflight-errors={{ ignore_preflight_errors }}{% endif %}
   when: inventory_hostname != groups['masters'][0] and node_type == "master"
 
 - name: Create a directory ${HOME}/.kube if it does not exist
@@ -134,5 +134,7 @@
   with_items: "{{ groups['all'] }}"
 
 - name: kubeadm join worker nodes
-  command: "{{ kubernetes_join_command }}"
+  command: >
+      {{ kubernetes_join_command }}
+      {% if ignore_preflight_errors != '' %} --ignore-preflight-errors={{ ignore_preflight_errors }}{% endif %}
   when: node_type == "worker"


### PR DESCRIPTION
This PR introduces changes to include the `ignore_preflight_errors` flag for kubeadm init to provide more flexibility to users.
Tested with combinations of one or more, and none of the options set for  `ignore-preflight-errors`.

```
"_raw_params": "kubeadm init --config /root/kubeadm.yaml --ignore-preflight-errors=SystemVerification\n", 
"_raw_params": "kubeadm init --config /root/kubeadm.yaml   --ignore-preflight-errors=SystemVerification,Swap\n",
"_raw_params": "kubeadm init --config /root/kubeadm.yaml  \n",
```

ignore_preflight_errors is with default of SystemVerification