### PR TITLE
Add condition for test-handler container runtime

### DIFF
--- a/kubetest2-tf/data/k8s-ansible/group_vars/all
+++ b/kubetest2-tf/data/k8s-ansible/group_vars/all
@@ -19,6 +19,7 @@ critools_version: 1.29.0
 runc_version: 1.1.12
 # valid runtimes: containerd [default], crio.
 runtime: containerd
+container_runtime_test_handler: false
 containerd_version: 1.7.13
 crio_version: 1.29.1
 pause_container_image: registry.k8s.io/pause:3.9

--- a/kubetest2-tf/data/k8s-ansible/roles/runtime/templates/containerd/config.toml.j2
+++ b/kubetest2-tf/data/k8s-ansible/roles/runtime/templates/containerd/config.toml.j2
@@ -57,6 +57,10 @@ version = 2
 {% if (cgroup_driver is defined) and 'systemd' == cgroup_driver %}
             SystemdCgroup = true
 {% endif %}
+{% if container_runtime_test_handler %}
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler]
+          runtime_type = "io.containerd.runc.v2"
+{% endif %}
     [plugins."io.containerd.grpc.v1.cri".cni]
       bin_dir = "/opt/cni/bin"
       conf_dir = "/etc/cni/net.d"


### PR DESCRIPTION
Added a conditional configuration block for the test-handler runtime in containerd config to support Kubernetes RuntimeClass tests.

This fixes the following test failure:
```
[FAIL] [sig-node] RuntimeClass [It] should run a Pod requesting a RuntimeClass with scheduling with taints [Serial] [sig-node, Serial]

Failed to create pod sandbox: rpc error: code = Unknown desc = failed to get sandbox runtime: no runtime for "test-handler" is configured
```