### PR TITLE
Added `| bool` to correctly check `container_runtime_test_handler` condition in containerd config

### DIFF
--- a/kubetest2-tf/data/k8s-ansible/roles/runtime/templates/containerd/config.toml.j2
+++ b/kubetest2-tf/data/k8s-ansible/roles/runtime/templates/containerd/config.toml.j2
@@ -57,7 +57,7 @@ version = 2
 {% if (cgroup_driver is defined) and 'systemd' == cgroup_driver %}
             SystemdCgroup = true
 {% endif %}
-{% if container_runtime_test_handler %}
+{% if container_runtime_test_handler|bool %}
         [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler]
           runtime_type = "io.containerd.runc.v2"
 {% endif %}


### PR DESCRIPTION
The container_runtime_test_handler variable is being treated as a string in Ansible.

Added `| bool` to `container_runtime_test_handler` to correctly interpret it as a boolean in the condition, ensuring the block only executes when true.

