### PR TITLE
Introduce an option to update packages during cluster setup

### DIFF
--- a/kubetest2-tf/data/k8s-ansible/group_vars/all
+++ b/kubetest2-tf/data/k8s-ansible/group_vars/all
@@ -10,6 +10,9 @@ ssh_private_key: "~/.ssh/id_rsa"
 username: <username>
 password: <password>
 
+##### Node OS/Package related updates #####
+update_os_packages: false
+
 # kubeconfig on the local machine where kubeconfig content will be copied from the remote machine
 kubeconfig_path: kubeconfig
 

--- a/kubetest2-tf/data/k8s-ansible/install-k8s.yml
+++ b/kubetest2-tf/data/k8s-ansible/install-k8s.yml
@@ -1,9 +1,16 @@
+- name: Prepare nodes with OS/Package updates
+  hosts:
+    - masters
+    - workers
+  roles:
+    - role: update-pkgs
+      when: update_os_packages | bool
+
 - name: Install Runtime and Kubernetes
   hosts:
     - masters
     - workers
   roles:
-    - update-pkgs
     - runtime
     - download-k8s
     - install-k8s


### PR DESCRIPTION
This PR introduces an option to choose between updating the nodes to setup kubernetes with the latest version of packages/kernel. 