### PR TITLE
Download and setup only required images on CP/worker nodes

### DIFF
--- a/kubetest2-tf/data/k8s-ansible/group_vars/all
+++ b/kubetest2-tf/data/k8s-ansible/group_vars/all
@@ -38,7 +38,6 @@ registry_mirrors:
 ##### Kubernetes Configurations #####
 k8s_tar_bundles:
   - kubernetes-test-linux-ppc64le.tar.gz
-  - kubernetes-client-linux-ppc64le.tar.gz
   - kubernetes-server-linux-ppc64le.tar.gz
 apiserver_port: 6443
 loadbalancer: ""

--- a/kubetest2-tf/data/k8s-ansible/install-k8s-perf.yml
+++ b/kubetest2-tf/data/k8s-ansible/install-k8s-perf.yml
@@ -1,7 +1,7 @@
 - hosts: all
   tasks:
     - set_fact:
-        prepull_images: "{{ prepull_images + ['registry.k8s.io/pause:3.9'] }}"
+        prepull_images: "{{ prepull_images + ['registry.k8s.io/pause:3.10'] }}"
 
 - name: Install Runtime and Kubernetes
   hosts:

--- a/kubetest2-tf/data/k8s-ansible/roles/download-k8s/tasks/main.yml
+++ b/kubetest2-tf/data/k8s-ansible/roles/download-k8s/tasks/main.yml
@@ -18,7 +18,7 @@
   retries: 3
   delay: 5
 
-- name: Import container images
+- name: Import control plane component container images
   shell: |
     export ARCH={{ ansible_architecture }}
     ctr -n k8s.io images import "/usr/local/bin/{{ item }}.tar"
@@ -27,5 +27,13 @@
     - kube-apiserver
     - kube-controller-manager
     - kubectl
-    - kube-proxy
     - kube-scheduler
+  when: node_type == "master"
+
+- name: Import common container images required for setting up cluster
+  shell: |
+    export ARCH={{ ansible_architecture }}
+    ctr -n k8s.io images import "/usr/local/bin/{{ item }}.tar"
+    ctr -n k8s.io images ls -q | grep -e {{ item }} | xargs -L 1 -I '{}' /bin/bash -c 'ctr -n k8s.io images tag "{}" "$(echo "{}" | sed s/-'$ARCH':/:/)"'
+  with_items:
+    - kube-proxy

--- a/kubetest2-tf/data/k8s-ansible/roles/install-k8s/tasks/main.yml
+++ b/kubetest2-tf/data/k8s-ansible/roles/install-k8s/tasks/main.yml
@@ -57,6 +57,7 @@
     src: kubeadm.yaml.j2
     dest: /root/kubeadm.yaml
     mode: '0644'
+  when: inventory_hostname == groups['masters'][0]
 
 - name: Perform kubeadm init on the control plane node based on LB configuration.
   command: >


### PR DESCRIPTION
This PR downloads and imports only the required containers and binaries on the respective kinds of nodes (control-plane/worker).  Additionally, downloading the `kubernetes-client-linux-ppc64le.tar.gz` bundle has not much value as the same contents are available in the `kubernetes-server-linux-ppc64le` tar bundle. 

These changes can help reduce the setup time to an extent, subject to network speeds. 

```
[root@kubetest2-tf1 release-tars]# tar -xvzf kubernetes-server-linux-ppc64le.tar.gz | grep kubectl
kubernetes/server/bin/kubectl
kubernetes/server/bin/kubectl.tar
kubernetes/server/bin/kubectl.docker_tag
kubernetes/server/bin/kubectl-convert 

[root@kubetest2-tf1 release-tars]# tar -xvzf kubernetes-client-linux-ppc64le.tar.gz
kubernetes/
kubernetes/client/
kubernetes/client/bin/
kubernetes/client/bin/kubectl
kubernetes/client/bin/kubectl-convert
```