### PR TITLE
CentOS Stream 10: Install required packages for k8s setup and e2e run

### DIFF
--- a/kubetest2-tf/data/k8s-ansible/install-k8s.yml
+++ b/kubetest2-tf/data/k8s-ansible/install-k8s.yml
@@ -4,7 +4,6 @@
     - workers
   roles:
     - role: update-pkgs
-      when: update_os_packages | bool
 
 - name: Install Runtime and Kubernetes
   hosts:

--- a/kubetest2-tf/data/k8s-ansible/roles/update-node-os/tasks/main.yaml
+++ b/kubetest2-tf/data/k8s-ansible/roles/update-node-os/tasks/main.yaml
@@ -6,7 +6,17 @@
   package:
     name: '*'
     state: latest
-  when: ansible_pkg_mgr in ['yum', 'dnf']
+  when: 
+   - ansible_pkg_mgr in ['yum', 'dnf']
+   - update_os_packages | bool
+   
+- name: Install kernel-modules-extra package for br_netfilter module
+  package:
+    name: kernel-modules-extra
+    state: present
+  when:
+    - ansible_pkg_mgr in ['yum', 'dnf']
+    - ansible_distribution_major_version | int >= 10
 
 - name: Check if reboot required
   shell: needs-restarting -r

--- a/kubetest2-tf/hack/ansible_install.sh
+++ b/kubetest2-tf/hack/ansible_install.sh
@@ -21,7 +21,7 @@ set -o pipefail
 install_ansible() {
     echo "Installing ansible..."
     ##Install ansible required to bring up k8s cluster on infra
-    apt-get update && apt-get install -y ansible
+    apt-get update && pip install --break-system-packages ansible
 }
 
 # Call if ansible not found


### PR DESCRIPTION
With CentOS Stream 10, the following issues were observed. This PR fixes these issues to ensure compatibility with CentOS Stream 10

1. `br_netfilter module not found error` - fixed by installing the kernel-modules-extra package.
3. `An unknown error occurred: HTTPSConnection.__init__() got an unexpected keyword argument 'cert_file' ` - caused by an outdated ansible version from the default package repository, which is incompatible with Python 3.12 on CentOS Stream 10. This was resolved by updating Ansible to the latest version using pip.