### PR TITLE
Expose system_type to main module

### DIFF
--- a/kubetest2-tf/data/powervs/main.tf
+++ b/kubetest2-tf/data/powervs/main.tf
@@ -22,6 +22,7 @@ module "master" {
   powervs_service_instance_id = var.powervs_service_id
   processors = var.controlplane_powervs_processors
   ssh_key_name = var.powervs_ssh_key
+  system_type = var.powervs_system_type
   storage_tier = var.powervs_storage_tier
   vm_name = "${var.cluster_name}-master"
   ibmcloud_region = var.powervs_region
@@ -39,6 +40,7 @@ module "workers" {
   powervs_service_instance_id = var.powervs_service_id
   processors = var.powervs_processors
   ssh_key_name = var.powervs_ssh_key
+  system_type = var.powervs_system_type
   storage_tier = var.powervs_storage_tier
   vm_name = "${var.cluster_name}-worker"
   ibmcloud_region = var.powervs_region

--- a/kubetest2-tf/data/powervs/variables-powervs.tf
+++ b/kubetest2-tf/data/powervs/variables-powervs.tf
@@ -58,6 +58,11 @@ variable "powervs_ssh_key" {
   description = "PowerVS SSH Key ID"
 }
 
+variable "powervs_system_type" {
+  description = "PowerVS Type of system on which the VM should be created e.g s922/e980"
+  default = "s922"
+}
+
 variable "powervs_region" {
   description = "PowerVS Region"
 }


### PR DESCRIPTION
Now this variable can be overridden by setting following variable:

```
export TF_VAR_powervs_system_type=e980
```