### PR TITLE
Add update-pkgs role to k8s-node-remote playbook

### DIFF
--- a/kubetest2-tf/data/k8s-ansible/k8s-node-remote.yml
+++ b/kubetest2-tf/data/k8s-ansible/k8s-node-remote.yml
@@ -2,6 +2,7 @@
   hosts:
     - masters
   roles:
+    - update-pkgs
     - disable-swap-selinux
     - install-bridge-cni
     - install-etcd


### PR DESCRIPTION
Add kernel-modules-extra task to playbook for CentOS Stream 10 compatibility -fix for https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-ppc64le-e2e-node-latest-kubetest2/1959845677903122432/build-log.txt