### PR TITLE
Add conditional reboot after kernel-modules-extra package update

### DIFF
--- a/kubetest2-tf/data/k8s-ansible/roles/update-node-os/tasks/main.yaml
+++ b/kubetest2-tf/data/k8s-ansible/roles/update-node-os/tasks/main.yaml
@@ -14,6 +14,7 @@
   package:
     name: kernel-modules-extra
     state: present
+  register: kmod_extra
   when:
     - ansible_pkg_mgr in ['yum', 'dnf']
     - ansible_distribution_major_version | int >= 10

--- a/kubetest2-tf/data/k8s-ansible/roles/update-pkgs/tasks/main.yml
+++ b/kubetest2-tf/data/k8s-ansible/roles/update-pkgs/tasks/main.yml
@@ -14,7 +14,8 @@
     name: update-node-os
   when: ansible_distribution in ['CentOS', 'RHEL']
 
-- name: Reboot if necessary
+- name: Reboot if kernel-modules-extra updated or reboot if necessary
   reboot:
-  when: reboot_check.rc == 1 and ansible_distribution in ['CentOS', 'RHEL']
-
+  when:
+    - ansible_distribution in ['CentOS', 'RedHat']
+    - kmod_extra.changed or reboot_check.rc == 1


### PR DESCRIPTION
Ensures the system reboots when the` kernel-modules-extra` package is installed or updated, or if `needs-restarting -r` indicates a reboot is needed. This fixes cases where needs-restarting might miss the reboot after `kernel-module-extra` changes.