### PR TITLE
Add make targets to build secretmanager and kubetest2-tf

### DIFF
--- a/kubetest2-tf/Makefile
+++ b/kubetest2-tf/Makefile
@@ -1,3 +1,17 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #Common uses:
 # installing a kubetest2-tf deployer: `make install-deployer-tf INSTALL_DIR=$HOME/go/bin`
 
@@ -31,3 +45,7 @@ install-deployer-tf: install-prereq
 	$(INSTALL) -d $(INSTALL_DIR)
 	$(INSTALL) $(OUT_DIR)/$(BINARY_NAME) $(INSTALL_DIR)/$(BINARY_NAME)
 .PHONY: install-deployer-tf
+
+build:
+	go build .
+.PHONY: build

--- a/secret-manager/Makefile
+++ b/secret-manager/Makefile
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-install-deployer-tf:
-	$(MAKE) -C kubetest2-tf/ install-deployer-tf
-build-deployer-tf:
-	$(MAKE) -C kubetest2-tf/ build
-build-secret-manager:
-	$(MAKE) -C secret-manager/ build
+build:
+	go build .
+.PHONY: build


### PR DESCRIPTION
Partially fixes: #42

Adding make targets for building of secretmanager and kubetest2 for onboarding prow jobs for build on kubernetes/test-infra.