### PR TITLE
Add playbook to set SMT on worker nodes

### DIFF
--- a/kubetest2-tf/data/k8s-ansible/group_vars/all
+++ b/kubetest2-tf/data/k8s-ansible/group_vars/all
@@ -13,6 +13,9 @@ password: <password>
 ##### Node OS/Package related updates #####
 update_os_packages: false
 
+##### Default SMT setting (applicable for ppc64le only)
+smt_level: 8
+
 # kubeconfig on the local machine where kubeconfig content will be copied from the remote machine
 kubeconfig_path: kubeconfig
 

--- a/kubetest2-tf/data/k8s-ansible/group_vars/workers
+++ b/kubetest2-tf/data/k8s-ansible/group_vars/workers
@@ -1,2 +1,3 @@
 ---
 node_type: worker
+smt_level: 4

--- a/kubetest2-tf/data/k8s-ansible/install-k8s-ha.yml
+++ b/kubetest2-tf/data/k8s-ansible/install-k8s-ha.yml
@@ -22,6 +22,13 @@
     - download-k8s
     - install-k8s
 
+- name: Set desired SMT levels on nodes
+  hosts:
+    - workers
+  roles:
+    - role: set-smt
+      when: ansible_architecture == 'ppc64le'
+
 - name: Install networking - calico
   hosts: masters
   roles:

--- a/kubetest2-tf/data/k8s-ansible/patch-nodes.yaml
+++ b/kubetest2-tf/data/k8s-ansible/patch-nodes.yaml
@@ -13,3 +13,10 @@
   become: yes
   roles:
     - role: reboot-sequentially
+
+- name: Set desired SMT levels on nodes
+  hosts:
+    - workers
+  roles:
+    - role: set-smt
+      when: ansible_architecture == 'ppc64le'

--- a/kubetest2-tf/data/k8s-ansible/roles/set-smt/tasks/main.yml
+++ b/kubetest2-tf/data/k8s-ansible/roles/set-smt/tasks/main.yml
@@ -1,0 +1,17 @@
+- name: Resolve Kubernetes node name from inventory IP
+  shell: |
+    kubectl get nodes -o jsonpath="{range .items[*]}{.metadata.name} {.status.addresses[?(@.type=='InternalIP')].address}{'\n'}{end}" \
+    --kubeconfig {{ kubeconfig_path }} | grep {{ inventory_hostname }} | awk '{print $1}'
+  register: node_name
+  delegate_to: "{{ groups['masters'][0] }}"
+
+- name: Add SMT level label to node
+  shell: |
+    kubectl label node/{{ node_name.stdout }} feature.node.kubernetes.io/ppc64le.smtlevel="{{ smt_level }}" --overwrite
+  delegate_to: "{{ groups['masters'][0] }}"
+
+- name: Set SMT level
+  shell: ppc64_cpu --smt={{ smt_level }}
+
+- name: Restart kubelet to update the node's capacity at the cluster level
+  shell: systemctl restart kubelet


### PR DESCRIPTION
This PR introduces an ansible role to set SMT while setting up the build cluster.

The relevant documentation surrounding this topic will be submitted to k8s.io/infra, along the steps involved while setting up the build cluster as a follow-up task. 