### PR TITLE
Fix parsing of extravars with multiple fields

### DIFF
--- a/kubetest2-tf/data/k8s-ansible/install-k8s-perf.yml
+++ b/kubetest2-tf/data/k8s-ansible/install-k8s-perf.yml
@@ -1,8 +1,3 @@
-- hosts: all
-  tasks:
-    - set_fact:
-        prepull_images: "{{ prepull_images + ['registry.k8s.io/pause:3.10'] }}"
-
 - name: Install Runtime and Kubernetes
   hosts:
     - masters

--- a/kubetest2-tf/data/k8s-ansible/roles/runtime/tasks/main.yaml
+++ b/kubetest2-tf/data/k8s-ansible/roles/runtime/tasks/main.yaml
@@ -70,5 +70,5 @@
 
 - name: Pre-pull sandbox-images in the test environment.
   shell: crictl pull {{ item }}
-  with_items: "{{ prepull_images }}"
+  with_items: "{{ (prepull_images | from_yaml if prepull_images is string else prepull_images) }}"
   when: prepull_images | length > 0

--- a/kubetest2-tf/deployer/deployer.go
+++ b/kubetest2-tf/deployer/deployer.go
@@ -18,8 +18,8 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/octago/sflags/gen/gpflag"
 	"github.com/spf13/pflag"
+	"github.com/urfave/sflags/gen/gpflag"
 
 	"sigs.k8s.io/boskos/client"
 
@@ -86,7 +86,7 @@ type deployer struct {
 	RetryOnTfFailure      int               `desc:"Retry on Terraform Apply Failure"`
 	BreakKubetestOnUpfail bool              `desc:"Breaks kubetest2 when up fails"`
 	Playbook              string            `desc:"Name of ansible playbook to be run"`
-	ExtraVars             map[string]string `desc:"Passes extra-vars to ansible playbook, enter a string of key=value pairs"`
+	ExtraVars             map[string]string `desc:"Passes extra-vars to ansible playbook, enter a string of key:value pairs"`
 	SetKubeconfig         bool              `desc:"Flag to set kubeconfig"`
 	TargetProvider        string            `desc:"provider value to be used(powervs, vpc)"`
 	// boskos struct field will be non-nil when the deployer is

--- a/kubetest2-tf/go.mod
+++ b/kubetest2-tf/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/IBM/ibm-cos-sdk-go v1.12.1
 	github.com/apenella/go-ansible/v2 v2.1.1
 	github.com/hashicorp/terraform-exec v0.22.0
-	github.com/octago/sflags v0.3.1
+	github.com/urfave/sflags v0.4.2-0.20260106141539-680a267d4b97
 	github.com/spf13/pflag v1.0.6
 	k8s.io/client-go v0.32.2
 	k8s.io/cluster-bootstrap v0.32.2

--- a/kubetest2-tf/go.sum
+++ b/kubetest2-tf/go.sum
@@ -615,8 +615,6 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=
 github.com/nxadm/tail v1.4.11/go.mod h1:OTaG3NK980DZzxbRq6lEuzgU+mug70nY11sMd4JXXHc=
-github.com/octago/sflags v0.3.1 h1:LW65z20iAQKteEyjsnnc+/lyoCUnIoRuAocggr6RB6A=
-github.com/octago/sflags v0.3.1/go.mod h1:hVUkbnYwMU9kZiZJyOAIVN56YiVMMPxgJ46kRZ19jh0=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/oleiade/reflections v1.0.1 h1:D1XO3LVEYroYskEsoSiGItp9RUxG6jWnCVvrqH0HHQM=
@@ -786,6 +784,8 @@ github.com/tjfoc/gmsm v1.4.1 h1:aMe1GlZb+0bLjn+cKTPEvvn9oUEBlJitaZiiBwsbgho=
 github.com/tjfoc/gmsm v1.4.1/go.mod h1:j4INPkHWMrhJb38G+J6W4Tw0AbuN8Thu3PbdVYhVcTE=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
+github.com/urfave/sflags v0.4.2-0.20260106141539-680a267d4b97 h1:jThfQp/VQxGg2I8pzaJno501uoJdEcVe1JOh3JCG0Dw=
+github.com/urfave/sflags v0.4.2-0.20260106141539-680a267d4b97/go.mod h1:NCIz2mBC+woyrkl88PeiKAuQUKJdEre2Y4at5SreAeU=
 github.com/vbatts/tar-split v0.11.5 h1:3bHCTIheBm1qFTcgh9oPu+nNBtX+XJIupG/vacinCts=
 github.com/vbatts/tar-split v0.11.5/go.mod h1:yZbwRsSeGjusneWgA781EKej9HF8vme8okylkAeNKLk=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=


### PR DESCRIPTION
The current design doesn't parse the complete set of key:value pairs passed to the --extra-vars flag. The implemented approach accepts the vars as a string and performs operations to allow them to be parsed separately. 

```
With the fix, the args are parsed as expected.
--extra-vars=prepull_images:'["registry.k8s.io/pause:3.9","registry.k8s.io/pause:3.10"]'

TASK [runtime : Pre-pull sandbox-images in the test environment.] **************
changed: [135.90.109.228] => (item=registry.k8s.io/pause:3.9)
changed: [135.90.109.227] => (item=registry.k8s.io/pause:3.9)
changed: [135.90.109.228] => (item=registry.k8s.io/pause:3.10)
changed: [135.90.109.227] => (item=registry.k8s.io/pause:3.10)
```

/hold - Until the PR is approved, as changes need to be done in a few job definitions. 