### PR TITLE
Use k8s-admin user and disable root SSH for s390x VPC and VSI resources

### DIFF
--- a/kubetest2-tf/data/k8s-ansible/roles/install-k8s/tasks/main.yml
+++ b/kubetest2-tf/data/k8s-ansible/roles/install-k8s/tasks/main.yml
@@ -134,8 +134,21 @@
   delegate_facts: true
   with_items: "{{ groups['all'] }}"
 
+- name: Fail clearly when worker join command is unavailable
+  fail:
+    msg: >-
+      kubernetes_join_command is unavailable for worker join. Inspect earlier
+      master-side failures, especially kubeadm init or kubeadm token creation
+      on {{ groups['masters'][0] }}.
+  when:
+    - node_type == "worker"
+    - kubernetes_join_command is not defined or (kubernetes_join_command | trim) == ""
+
 - name: kubeadm join worker nodes
   command: >
       {{ kubernetes_join_command }}
       {% if ignore_preflight_errors != '' %} --ignore-preflight-errors={{ ignore_preflight_errors }}{% endif %}
-  when: node_type == "worker"
+  when:
+    - node_type == "worker"
+    - kubernetes_join_command is defined
+    - (kubernetes_join_command | trim) != ""

--- a/kubetest2-tf/data/k8s-ansible/roles/install-k8s/tasks/main.yml
+++ b/kubetest2-tf/data/k8s-ansible/roles/install-k8s/tasks/main.yml
@@ -134,21 +134,9 @@
   delegate_facts: true
   with_items: "{{ groups['all'] }}"
 
-- name: Fail clearly when worker join command is unavailable
-  fail:
-    msg: >-
-      kubernetes_join_command is unavailable for worker join. Inspect earlier
-      master-side failures, especially kubeadm init or kubeadm token creation
-      on {{ groups['masters'][0] }}.
-  when:
-    - node_type == "worker"
-    - kubernetes_join_command is not defined or (kubernetes_join_command | trim) == ""
-
 - name: kubeadm join worker nodes
   command: >
       {{ kubernetes_join_command }}
       {% if ignore_preflight_errors != '' %} --ignore-preflight-errors={{ ignore_preflight_errors }}{% endif %}
-  when:
-    - node_type == "worker"
-    - kubernetes_join_command is defined
-    - (kubernetes_join_command | trim) != ""
+  when: node_type == "worker"
+  

--- a/kubetest2-tf/data/k8s-ansible/roles/install-k8s/tasks/main.yml
+++ b/kubetest2-tf/data/k8s-ansible/roles/install-k8s/tasks/main.yml
@@ -125,20 +125,8 @@
   when: node_type == "master"
   register: kubernetes_join_command_result
 
-- name: Set the kubeadm join command globally.
-  set_fact:
-    kubernetes_join_command: >
-      {{ kubernetes_join_command_result.stdout }}
-  when: kubernetes_join_command_result.stdout is defined
-  delegate_to: "{{ item }}"
-  delegate_facts: true
-  with_items: "{{ groups['all'] }}"
-
 - name: kubeadm join worker nodes
   command: >
-      {{ kubernetes_join_command }}
-      {% if ignore_preflight_errors != '' %} --ignore-preflight-errors={{ ignore_preflight_errors }}{% endif %}
-  when:
-    - node_type == "worker"
-    - kubernetes_join_command is defined
-    - (kubernetes_join_command | trim) != ""
+    {{ hostvars[groups['masters'][0]].kubernetes_join_command_result.stdout }}
+    {% if ignore_preflight_errors != '' %} --ignore-preflight-errors={{ ignore_preflight_errors }}{% endif %}
+  when: node_type == "worker"

--- a/kubetest2-tf/data/k8s-ansible/roles/install-k8s/tasks/main.yml
+++ b/kubetest2-tf/data/k8s-ansible/roles/install-k8s/tasks/main.yml
@@ -138,5 +138,7 @@
   command: >
       {{ kubernetes_join_command }}
       {% if ignore_preflight_errors != '' %} --ignore-preflight-errors={{ ignore_preflight_errors }}{% endif %}
-  when: node_type == "worker"
-  
+  when:
+    - node_type == "worker"
+    - kubernetes_join_command is defined
+    - (kubernetes_join_command | trim) != ""

--- a/kubetest2-tf/data/k8s-ansible/roles/install-k8s/tasks/main.yml
+++ b/kubetest2-tf/data/k8s-ansible/roles/install-k8s/tasks/main.yml
@@ -125,17 +125,8 @@
   when: node_type == "master"
   register: kubernetes_join_command_result
 
-- name: Set the kubeadm join command globally.
-  set_fact:
-    kubernetes_join_command: >
-      {{ kubernetes_join_command_result.stdout }}
-  when: kubernetes_join_command_result.stdout is defined
-  delegate_to: "{{ item }}"
-  delegate_facts: true
-  with_items: "{{ groups['all'] }}"
-
 - name: kubeadm join worker nodes
   command: >
-      {{ kubernetes_join_command }}
-      {% if ignore_preflight_errors != '' %} --ignore-preflight-errors={{ ignore_preflight_errors }}{% endif %}
+    {{ hostvars[groups['masters'][0]].kubernetes_join_command_result.stdout }}
+    {% if ignore_preflight_errors != '' %} --ignore-preflight-errors={{ ignore_preflight_errors }}{% endif %}
   when: node_type == "worker"

--- a/kubetest2-tf/data/vpc/main.tf
+++ b/kubetest2-tf/data/vpc/main.tf
@@ -37,6 +37,25 @@ resource "ibm_is_instance_template" "node_template" {
     subnet          = local.subnet_id
     security_groups = [local.security_group_id]
   }
+
+  user_data = <<-EOT
+#cloud-config
+users:
+  - default
+  - name: k8s-admin
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [sudo]
+    ssh_authorized_keys:
+      - ${data.ibm_is_ssh_key.ssh_key.public_key}
+runcmd:
+  - |
+    # Ensure k8s-admin SSH dir has correct permissions
+    mkdir -p /home/k8s-admin/.ssh
+    chown -R k8s-admin:k8s-admin /home/k8s-admin/.ssh
+    chmod 700 /home/k8s-admin/.ssh
+    chmod 600 /home/k8s-admin/.ssh/authorized_keys
+EOT
 }
 
 module "master" {
@@ -59,32 +78,104 @@ module "workers" {
 }
 
 resource "null_resource" "wait-for-master-completes" {
+  depends_on = [module.master]
+  
+  # First wait for cloud-init to complete using root user (still available during boot)
+  provisioner "local-exec" {
+    command = <<-EOT
+      max_attempts=60
+      attempt=0
+      while [ $attempt -lt $max_attempts ]; do
+        # Try k8s-admin first (root SSH is disabled on new IBM Cloud VPC-VSIs)
+        if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
+               -i ${var.ssh_private_key} k8s-admin@${module.master.public_ip} \
+               "sudo cloud-init status --wait" 2>/dev/null; then
+          echo "Cloud-init completed on master (via k8s-admin)"
+          break
+        fi
+        # Fallback to root for older images that still have root SSH enabled
+        if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
+               -i ${var.ssh_private_key} root@${module.master.public_ip} \
+               "cloud-init status --wait" 2>/dev/null; then
+          echo "Cloud-init completed on master (via root)"
+          break
+        fi
+        attempt=$((attempt + 1))
+        echo "Waiting for cloud-init on master (attempt $attempt/$max_attempts)..."
+        sleep 10
+      done
+      if [ $attempt -eq $max_attempts ]; then
+        echo "ERROR: Timed out waiting for cloud-init on master"
+        exit 1
+      fi
+    EOT
+  }
+  
+  # Then verify k8s-admin user is accessible
   connection {
     type        = "ssh"
-    user        = "root"
+    user        = "k8s-admin"
     host        = module.master.public_ip
     private_key = file(var.ssh_private_key)
-    timeout     = "20m"
+    timeout     = "5m"
   }
   provisioner "remote-exec" {
     inline = [
-      "cloud-init status -w"
+      "echo 'k8s-admin user is ready on master'"
     ]
   }
 }
 
 resource "null_resource" "wait-for-workers-completes" {
-  count = var.workers_count
+  count      = var.workers_count
+  depends_on = [module.workers]
+  
+  # First wait for cloud-init to complete using root user (still available during boot)
+  provisioner "local-exec" {
+    command = <<-EOT
+      max_attempts=60
+      attempt=0
+      worker_ip="${module.workers[count.index].public_ip}"
+      worker_index="${count.index}"
+      ssh_key="${var.ssh_private_key}"
+      
+      while [ $attempt -lt $max_attempts ]; do
+        # Try k8s-admin first (root SSH is disabled on new IBM Cloud VPC-VSIs)
+        if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
+               -i "$ssh_key" k8s-admin@"$worker_ip" \
+               "sudo cloud-init status --wait" 2>/dev/null; then
+          echo "Cloud-init completed on worker $worker_index (via k8s-admin)"
+          break
+        fi
+        # Fallback to root for older images that still have root SSH enabled
+        if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
+               -i "$ssh_key" root@"$worker_ip" \
+               "cloud-init status --wait" 2>/dev/null; then
+          echo "Cloud-init completed on worker $worker_index (via root)"
+          break
+        fi
+        attempt=$((attempt + 1))
+        echo "Waiting for cloud-init on worker $worker_index (attempt $attempt/$max_attempts)..."
+        sleep 10
+      done
+      if [ $attempt -eq $max_attempts ]; then
+        echo "ERROR: Timed out waiting for cloud-init on worker $worker_index"
+        exit 1
+      fi
+    EOT
+  }
+  
+  # Then verify k8s-admin user is accessible
   connection {
     type        = "ssh"
-    user        = "root"
+    user        = "k8s-admin"
     host        = module.workers[count.index].public_ip
     private_key = file(var.ssh_private_key)
-    timeout     = "15m"
+    timeout     = "5m"
   }
   provisioner "remote-exec" {
     inline = [
-      "cloud-init status -w"
+      "echo 'k8s-admin user is ready on worker ${count.index}'"
     ]
   }
 }

--- a/kubetest2-tf/data/vpc/main.tf
+++ b/kubetest2-tf/data/vpc/main.tf
@@ -37,6 +37,25 @@ resource "ibm_is_instance_template" "node_template" {
     subnet          = local.subnet_id
     security_groups = [local.security_group_id]
   }
+
+  user_data = <<-EOT
+#cloud-config
+users:
+  - default
+  - name: k8s-admin
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [sudo]
+    ssh_authorized_keys:
+      - ${data.ibm_is_ssh_key.ssh_key.public_key}
+runcmd:
+  - |
+    # Ensure k8s-admin SSH dir has correct permissions
+    mkdir -p /home/k8s-admin/.ssh
+    chown -R k8s-admin:k8s-admin /home/k8s-admin/.ssh
+    chmod 700 /home/k8s-admin/.ssh
+    chmod 600 /home/k8s-admin/.ssh/authorized_keys
+EOT
 }
 
 module "master" {
@@ -59,32 +78,104 @@ module "workers" {
 }
 
 resource "null_resource" "wait-for-master-completes" {
+  depends_on = [module.master]
+  
+  # First wait for cloud-init to complete using root user (still available during boot)
+  provisioner "local-exec" {
+    command = <<-EOT
+      max_attempts=60
+      attempt=0
+      success=0
+      # Try k8s-admin first (root SSH is disabled on new IBM Cloud VPC-VSIs).
+      # Fallback to root for older images that still have root SSH enabled.
+      while [ $attempt -lt $max_attempts ]; do
+        for user in "k8s-admin" "root"; do
+          cmd_prefix=$([ "$user" = "root" ] && echo "" || echo "sudo")
+          if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
+                 -i ${var.ssh_private_key} "$user"@${module.master.public_ip} \
+                 "$cmd_prefix cloud-init status --wait" 2>/dev/null; then
+            echo "Cloud-init completed on master (via $user)"
+            success=1
+            break
+          fi
+        done
+        [ $success -eq 1 ] && break
+        attempt=$((attempt + 1))
+        echo "Waiting for cloud-init on master (attempt $attempt/$max_attempts)..."
+        sleep 10
+      done
+      if [ $success -ne 1 ]; then
+        echo "ERROR: Timed out waiting for cloud-init on master"
+        exit 1
+      fi
+    EOT
+  }
+  
+  # Then verify k8s-admin user is accessible
   connection {
     type        = "ssh"
-    user        = "root"
+    user        = "k8s-admin"
     host        = module.master.public_ip
     private_key = file(var.ssh_private_key)
-    timeout     = "20m"
+    timeout     = "5m"
   }
   provisioner "remote-exec" {
     inline = [
-      "cloud-init status -w"
+      "echo 'k8s-admin user is ready on master'"
     ]
   }
 }
 
 resource "null_resource" "wait-for-workers-completes" {
-  count = var.workers_count
+  count      = var.workers_count
+  depends_on = [module.workers]
+  
+  # First wait for cloud-init to complete using root user (still available during boot)
+  provisioner "local-exec" {
+    command = <<-EOT
+      max_attempts=60
+      attempt=0
+      success=0
+      worker_ip="${module.workers[count.index].public_ip}"
+      worker_index="${count.index}"
+      ssh_key="${var.ssh_private_key}"
+
+      # Try k8s-admin first (root SSH is disabled on new IBM Cloud VPC-VSIs).
+      # Fallback to root for older images that still have root SSH enabled.
+      while [ $attempt -lt $max_attempts ]; do
+        for user in "k8s-admin" "root"; do
+          cmd_prefix=$([ "$user" = "root" ] && echo "" || echo "sudo")
+          if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
+                 -i "$ssh_key" "$user"@"$worker_ip" \
+                 "$cmd_prefix cloud-init status --wait" 2>/dev/null; then
+            echo "Cloud-init completed on worker $worker_index (via $user)"
+            success=1
+            break
+          fi
+        done
+        [ $success -eq 1 ] && break
+        attempt=$((attempt + 1))
+        echo "Waiting for cloud-init on worker $worker_index (attempt $attempt/$max_attempts)..."
+        sleep 10
+      done
+      if [ $success -ne 1 ]; then
+        echo "ERROR: Timed out waiting for cloud-init on worker $worker_index"
+        exit 1
+      fi
+    EOT
+  }
+  
+  # Then verify k8s-admin user is accessible
   connection {
     type        = "ssh"
-    user        = "root"
+    user        = "k8s-admin"
     host        = module.workers[count.index].public_ip
     private_key = file(var.ssh_private_key)
-    timeout     = "15m"
+    timeout     = "5m"
   }
   provisioner "remote-exec" {
     inline = [
-      "cloud-init status -w"
+      "echo 'k8s-admin user is ready on worker ${count.index}'"
     ]
   }
 }

--- a/kubetest2-tf/data/vpc/main.tf
+++ b/kubetest2-tf/data/vpc/main.tf
@@ -85,26 +85,26 @@ resource "null_resource" "wait-for-master-completes" {
     command = <<-EOT
       max_attempts=60
       attempt=0
+      success=0
+      # Try k8s-admin first (root SSH is disabled on new IBM Cloud VPC-VSIs).
+      # Fallback to root for older images that still have root SSH enabled.
       while [ $attempt -lt $max_attempts ]; do
-        # Try k8s-admin first (root SSH is disabled on new IBM Cloud VPC-VSIs)
-        if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
-               -i ${var.ssh_private_key} k8s-admin@${module.master.public_ip} \
-               "sudo cloud-init status --wait" 2>/dev/null; then
-          echo "Cloud-init completed on master (via k8s-admin)"
-          break
-        fi
-        # Fallback to root for older images that still have root SSH enabled
-        if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
-               -i ${var.ssh_private_key} root@${module.master.public_ip} \
-               "cloud-init status --wait" 2>/dev/null; then
-          echo "Cloud-init completed on master (via root)"
-          break
-        fi
+        for user in "k8s-admin" "root"; do
+          cmd_prefix=$([ "$user" = "root" ] && echo "" || echo "sudo")
+          if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
+                 -i ${var.ssh_private_key} "$user"@${module.master.public_ip} \
+                 "$cmd_prefix cloud-init status --wait" 2>/dev/null; then
+            echo "Cloud-init completed on master (via $user)"
+            success=1
+            break
+          fi
+        done
+        [ $success -eq 1 ] && break
         attempt=$((attempt + 1))
         echo "Waiting for cloud-init on master (attempt $attempt/$max_attempts)..."
         sleep 10
       done
-      if [ $attempt -eq $max_attempts ]; then
+      if [ $success -ne 1 ]; then
         echo "ERROR: Timed out waiting for cloud-init on master"
         exit 1
       fi
@@ -135,30 +135,30 @@ resource "null_resource" "wait-for-workers-completes" {
     command = <<-EOT
       max_attempts=60
       attempt=0
+      success=0
       worker_ip="${module.workers[count.index].public_ip}"
       worker_index="${count.index}"
       ssh_key="${var.ssh_private_key}"
-      
+
+      # Try k8s-admin first (root SSH is disabled on new IBM Cloud VPC-VSIs).
+      # Fallback to root for older images that still have root SSH enabled.
       while [ $attempt -lt $max_attempts ]; do
-        # Try k8s-admin first (root SSH is disabled on new IBM Cloud VPC-VSIs)
-        if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
-               -i "$ssh_key" k8s-admin@"$worker_ip" \
-               "sudo cloud-init status --wait" 2>/dev/null; then
-          echo "Cloud-init completed on worker $worker_index (via k8s-admin)"
-          break
-        fi
-        # Fallback to root for older images that still have root SSH enabled
-        if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
-               -i "$ssh_key" root@"$worker_ip" \
-               "cloud-init status --wait" 2>/dev/null; then
-          echo "Cloud-init completed on worker $worker_index (via root)"
-          break
-        fi
+        for user in "k8s-admin" "root"; do
+          cmd_prefix=$([ "$user" = "root" ] && echo "" || echo "sudo")
+          if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 \
+                 -i "$ssh_key" "$user"@"$worker_ip" \
+                 "$cmd_prefix cloud-init status --wait" 2>/dev/null; then
+            echo "Cloud-init completed on worker $worker_index (via $user)"
+            success=1
+            break
+          fi
+        done
+        [ $success -eq 1 ] && break
         attempt=$((attempt + 1))
         echo "Waiting for cloud-init on worker $worker_index (attempt $attempt/$max_attempts)..."
         sleep 10
       done
-      if [ $attempt -eq $max_attempts ]; then
+      if [ $success -ne 1 ]; then
         echo "ERROR: Timed out waiting for cloud-init on worker $worker_index"
         exit 1
       fi

--- a/kubetest2-tf/deployer/deployer.go
+++ b/kubetest2-tf/deployer/deployer.go
@@ -258,8 +258,8 @@ func (d *deployer) Up() error {
 				if !d.BreakKubetestOnUpfail {
 					return fmt.Errorf("terraform Apply failed. Error: %v", err)
 				}
-				klog.Infof("Terraform Apply failed. Look into it and delete the resources")
-				klog.Infof("terraform.Apply error: %v", err)
+				klog.Errorf("Terraform Apply failed. Breaking kubetest on up failure.")
+				klog.Errorf("terraform.Apply error: %v", err)
 				os.Exit(1)
 			}
 			continue

--- a/kubetest2-tf/deployer/dumplogs.go
+++ b/kubetest2-tf/deployer/dumplogs.go
@@ -20,9 +20,15 @@ var commandFilename = map[string]string{
 func (d *deployer) DumpClusterLogs() error {
 	var errors []error
 	var stdErr, stdOut bytes.Buffer
+	sshUser := "root"
 
 	// Set exclusively as maps are declared during compile-time and may be set with defaults.
 	commandFilename[common.CommonProvider.Runtime] = fmt.Sprintf("journalctl -xeu %s --no-pager", common.CommonProvider.Runtime)
+	if d.TargetProvider == "vpc" {
+		sshUser = "k8s-admin"
+		commandFilename["dmesg"] = "sudo dmesg"
+		commandFilename[common.CommonProvider.Runtime] = fmt.Sprintf("sudo journalctl -xeu %s --no-pager", common.CommonProvider.Runtime)
+	}
 
 	klog.Infof("Collecting cluster logs under %s", d.logsDir)
 	// create a directory based on the generated path: _rundir/dump-cluster-logs
@@ -69,7 +75,7 @@ func (d *deployer) DumpClusterLogs() error {
 				"ssh",
 				"-i",
 				common.CommonProvider.SSHPrivateKey,
-				fmt.Sprintf("root@%s", machineIP),
+				fmt.Sprintf("%s@%s", sshUser, machineIP),
 				command,
 			}
 			klog.V(1).Infof("Remotely executing command: %s", commandArgs)

--- a/kubetest2-tf/deployer/dumplogs.go
+++ b/kubetest2-tf/deployer/dumplogs.go
@@ -13,22 +13,16 @@ import (
 )
 
 var commandFilename = map[string]string{
-	"dmesg":    "dmesg",
+	"dmesg":    "sudo dmesg",
 	"kernel":   "sudo journalctl --no-pager --output=short-precise -k",
 	"services": "sudo systemctl list-units -t service --no-pager --no-legend --all"}
 
 func (d *deployer) DumpClusterLogs() error {
 	var errors []error
 	var stdErr, stdOut bytes.Buffer
-	sshUser := "root"
 
 	// Set exclusively as maps are declared during compile-time and may be set with defaults.
-	commandFilename[common.CommonProvider.Runtime] = fmt.Sprintf("journalctl -xeu %s --no-pager", common.CommonProvider.Runtime)
-	if d.TargetProvider == "vpc" {
-		sshUser = "k8s-admin"
-		commandFilename["dmesg"] = "sudo dmesg"
-		commandFilename[common.CommonProvider.Runtime] = fmt.Sprintf("sudo journalctl -xeu %s --no-pager", common.CommonProvider.Runtime)
-	}
+	commandFilename[common.CommonProvider.Runtime] = fmt.Sprintf("sudo journalctl -xeu %s --no-pager", common.CommonProvider.Runtime)
 
 	klog.Infof("Collecting cluster logs under %s", d.logsDir)
 	// create a directory based on the generated path: _rundir/dump-cluster-logs
@@ -66,6 +60,10 @@ func (d *deployer) DumpClusterLogs() error {
 	}
 
 	// Todo: Include provider specific logic in this section. (Includes node level information/CRI/Services, etc.)
+	sshUser := "root"
+	if d.TargetProvider == "vpc" {
+		sshUser = "k8s-admin"
+	}
 	for _, machineIP := range d.machineIPs {
 		klog.Infof("Collecting node level information from instance %s", machineIP)
 		for logFile, command := range commandFilename {

--- a/kubetest2-tf/deployer/dumplogs.go
+++ b/kubetest2-tf/deployer/dumplogs.go
@@ -13,7 +13,7 @@ import (
 )
 
 var commandFilename = map[string]string{
-	"dmesg":    "dmesg",
+	"dmesg":    "sudo dmesg",
 	"kernel":   "sudo journalctl --no-pager --output=short-precise -k",
 	"services": "sudo systemctl list-units -t service --no-pager --no-legend --all"}
 
@@ -22,7 +22,7 @@ func (d *deployer) DumpClusterLogs() error {
 	var stdErr, stdOut bytes.Buffer
 
 	// Set exclusively as maps are declared during compile-time and may be set with defaults.
-	commandFilename[common.CommonProvider.Runtime] = fmt.Sprintf("journalctl -xeu %s --no-pager", common.CommonProvider.Runtime)
+	commandFilename[common.CommonProvider.Runtime] = fmt.Sprintf("sudo journalctl -xeu %s --no-pager", common.CommonProvider.Runtime)
 
 	klog.Infof("Collecting cluster logs under %s", d.logsDir)
 	// create a directory based on the generated path: _rundir/dump-cluster-logs
@@ -60,6 +60,10 @@ func (d *deployer) DumpClusterLogs() error {
 	}
 
 	// Todo: Include provider specific logic in this section. (Includes node level information/CRI/Services, etc.)
+	sshUser := "root"
+	if d.TargetProvider == "vpc" {
+		sshUser = "k8s-admin"
+	}
 	for _, machineIP := range d.machineIPs {
 		klog.Infof("Collecting node level information from instance %s", machineIP)
 		for logFile, command := range commandFilename {
@@ -69,7 +73,7 @@ func (d *deployer) DumpClusterLogs() error {
 				"ssh",
 				"-i",
 				common.CommonProvider.SSHPrivateKey,
-				fmt.Sprintf("root@%s", machineIP),
+				fmt.Sprintf("%s@%s", sshUser, machineIP),
 				command,
 			}
 			klog.V(1).Infof("Remotely executing command: %s", commandArgs)


### PR DESCRIPTION
-  Disable root SSH access on newly created VPC–VSI instances
- Introduce and use a dedicated non-root user `k8s-admin` for all automation
- Grant required privileges via sudo (wheel group), instead of direct root login
- removed dependency on `ansible_become_user: root`
- updated the Ansible worker join task to read the kubeadm join command directly from the master hostvars:
  `hostvars[groups['masters'][0]].kubernetes_join_command_result.stdout`
- removed the older `set_fact + delegate_facts` based join-command propagation since the copied variable is no longer needed