### PR TITLE
Run set-smt role before uncordoning the node

### DIFF
--- a/kubetest2-tf/data/k8s-ansible/patch-nodes.yaml
+++ b/kubetest2-tf/data/k8s-ansible/patch-nodes.yaml
@@ -13,10 +13,3 @@
   become: yes
   roles:
     - role: reboot-sequentially
-
-- name: Set desired SMT levels on nodes
-  hosts:
-    - workers
-  roles:
-    - role: set-smt
-      when: ansible_architecture == 'ppc64le'

--- a/kubetest2-tf/data/k8s-ansible/roles/reboot-sequentially/tasks/main.yaml
+++ b/kubetest2-tf/data/k8s-ansible/roles/reboot-sequentially/tasks/main.yaml
@@ -18,8 +18,8 @@
         kubectl get pods -n test-pods \
         --kubeconfig {{ kubeconfig_path }} \
         --field-selector spec.nodeName={{ node_name.stdout }},status.phase=Running \
-        -o go-template={% raw %}'{{range .items}}{{if or (not .metadata.ownerReferences) (ne (index .metadata.ownerReferences 0).kind "DaemonSet")}}{{.metadata.name}}{{"\n"}} {{end}}{{end}}'{% endraw %} \
-        | wc -l
+        -o go-template={% raw %}'{{range .items}}{{if or (not .metadata.ownerReferences) (ne (index .metadata.ownerReferences 0).kind "DaemonSet")}}{{.metadata.name}}{{"\n"}}{{end}}{{end}}'{% endraw %} \
+        | grep -v boskos | wc -l
       register: running_pod_count
       retries: 360
       delay: 30
@@ -53,6 +53,11 @@
       retries: 20
       delay: 15
       delegate_to: "{{ groups['masters'][0] }}"
+
+    - name: Set desired SMT levels on nodes
+      include_role:
+        name: set-smt
+      when: ansible_architecture == 'ppc64le' and node_type == "worker"
 
     - name: Uncordon the node
       shell: kubectl uncordon {{ node_name.stdout }} --kubeconfig {{ kubeconfig_path }}


### PR DESCRIPTION
The current changes set the SMT and restart the kubelet once the node has been uncordoned. In this case, if there are any pending pods, post uncordon, the workloads tend to get scheduled on the uncordoned node. The task of setting the SMT and restarting the kubelet after the workload has been deployed can cause disruption as the number of CPUs available at the node tend to change upon changing SMT. 

This PR handles the SMT changes and the subsequent kubelet restart from the `set-smt` role before the node is made available in the pool.