### PR TITLE
Enable override for OUT_DIR to allow installation to custom paths

### DIFF
--- a/kubetest2-tf/Makefile
+++ b/kubetest2-tf/Makefile
@@ -26,7 +26,7 @@ help: ## This help message
 # get the repo root and output path
 REPO_ROOT:=$(shell pwd)
 export REPO_ROOT
-OUT_DIR=$(REPO_ROOT)/bin
+OUT_DIR?=$(REPO_ROOT)/bin
 # record the source commit in the binary, overridable
 INSTALL?=install
 # make install will place binaries here


### PR DESCRIPTION
This PR is to allow the overriding of OUT_DIR to install the plugins in certain paths as the current definition does not allow it to be overridden in cases where the plugin needs to be built from the changes, as in the case of a presubmit job.