### PR TITLE
cleanup: Do away with redundant invocation of terraform.Output and align variable types

### DIFF
--- a/kubetest2-tf/deployer/deployer.go
+++ b/kubetest2-tf/deployer/deployer.go
@@ -146,11 +146,11 @@ func (d *deployer) initialize() error {
 	if d.commonOptions.ShouldUp() {
 		needBoskos := false
 		switch d.TargetProvider {
-			case "vpc":
-				needBoskos = vpc.VPCProvider.Region == "" || vpc.VPCProvider.Zone == "" || vpc.VPCProvider.ResourceGroup == ""
-			case "powervs":
-        	    needBoskos = powervs.PowerVSProvider.Zone == "" || powervs.PowerVSProvider.Region == "" || powervs.PowerVSProvider.ServiceID == ""
-   		 }
+		case "vpc":
+			needBoskos = vpc.VPCProvider.Region == "" || vpc.VPCProvider.Zone == "" || vpc.VPCProvider.ResourceGroup == ""
+		case "powervs":
+			needBoskos = powervs.PowerVSProvider.Zone == "" || powervs.PowerVSProvider.Region == "" || powervs.PowerVSProvider.ServiceID == ""
+		}
 		if needBoskos {
 			klog.V(1).Info("No proper Resource detail provided, acquiring from Boskos")
 
@@ -173,16 +173,16 @@ func (d *deployer) initialize() error {
 			}
 			d.BoskosResourceUserData = resource.UserData.ToMap()
 			switch d.TargetProvider {
-				case "vpc":
-					vpc.VPCProvider.Region = d.BoskosResourceUserData["region"]
-					vpc.VPCProvider.Zone = d.BoskosResourceUserData["zone"]
-					vpc.VPCProvider.ResourceGroup = d.BoskosResourceUserData["resource-group"]
-					vpc.VPCProvider.VPCName = d.BoskosResourceUserData["vpc-name"]
+			case "vpc":
+				vpc.VPCProvider.Region = d.BoskosResourceUserData["region"]
+				vpc.VPCProvider.Zone = d.BoskosResourceUserData["zone"]
+				vpc.VPCProvider.ResourceGroup = d.BoskosResourceUserData["resource-group"]
+				vpc.VPCProvider.VPCName = d.BoskosResourceUserData["vpc-name"]
 
-				case "powervs":
-					powervs.PowerVSProvider.Zone = d.BoskosResourceUserData["zone"]
-					powervs.PowerVSProvider.Region = d.BoskosResourceUserData["region"]
-					powervs.PowerVSProvider.ServiceID = d.BoskosResourceUserData["service-instance-id"]
+			case "powervs":
+				powervs.PowerVSProvider.Zone = d.BoskosResourceUserData["zone"]
+				powervs.PowerVSProvider.Region = d.BoskosResourceUserData["region"]
+				powervs.PowerVSProvider.ServiceID = d.BoskosResourceUserData["service-instance-id"]
 			}
 			d.BoskosResourceName = resource.Name
 			klog.V(1).Infof("Got resource %s from boskos", d.BoskosResourceName)
@@ -251,29 +251,26 @@ func (d *deployer) Up() error {
 	}
 	for i := 0; i <= d.RetryOnTfFailure; i++ {
 		path, err := terraform.Apply(d.tmpDir, d.TargetProvider)
-		op, oerr := terraform.Output(d.tmpDir, d.TargetProvider)
 		if err != nil {
 			if i == d.RetryOnTfFailure {
-				fmt.Printf("terraform.Output: %s\nterraform.Output error: %v\n", op, oerr)
 				if !d.BreakKubetestOnUpfail {
-					return fmt.Errorf("terraform Apply failed. Error: %v", err)
+					return fmt.Errorf("terraform Apply failed. Error: %w", err)
 				}
-				klog.Infof("Terraform Apply failed. Look into it and delete the resources")
-				klog.Infof("terraform.Apply error: %v", err)
-				os.Exit(1)
+				klog.Errorf("Terraform Apply failed despite retries. Delete the deployed resources manually.")
+				return fmt.Errorf("Failed to Up() despite retries. Error: %w", err)
 			}
 			continue
-		} else {
-			fmt.Printf("terraform.Output: %s\nterraform.Output error: %v\n", op, oerr)
-			fmt.Printf("Terraform State at: %s\n", path)
-			break
 		}
+		klog.Infof("Terraform State is stored to %s", path)
+		break
 	}
 	inventory := AnsibleInventory{}
 	tfMetaOutput, err := terraform.Output(d.tmpDir, d.TargetProvider)
 	if err != nil {
+		klog.Errorf("Error while running terraform output. Error: %v", err)
 		return err
 	}
+	fmt.Println("Terraform output: %v\n", tfMetaOutput)
 	var tfOutput map[string][]interface{}
 	data, err := json.Marshal(tfMetaOutput)
 	if err != nil {

--- a/kubetest2-tf/pkg/providers/powervs/powervs.go
+++ b/kubetest2-tf/pkg/providers/powervs/powervs.go
@@ -56,10 +56,10 @@ func (p *Provider) BindFlags(flags *pflag.FlagSet) {
 	flags.StringVar(
 		&p.ImageName, "powervs-image-name", "", "Image ID(command: ibmcloud pi img ls)",
 	)
-	flags.Float64Var(
+	flags.Uint16Var(
 		&p.Memory, "powervs-memory", 8, "Memory in GBs",
 	)
-	flags.Float64Var(
+	flags.Float32Var(
 		&p.Processors, "powervs-processors", 0.5, "Processor Units",
 	)
 	flags.StringVar(

--- a/kubetest2-tf/pkg/tfvars/powervs/powervs.go
+++ b/kubetest2-tf/pkg/tfvars/powervs/powervs.go
@@ -5,9 +5,9 @@ type TFVars struct {
 	DNSName       string  `json:"powervs_dns"`
 	DNSZone       string  `json:"powervs_dns_zone"`
 	ImageName     string  `json:"powervs_image_name"`
-	Memory        float64 `json:"powervs_memory"`
+	Memory        uint16  `json:"powervs_memory"`
 	NetworkName   string  `json:"powervs_network_name"`
-	Processors    float64 `json:"powervs_processors"`
+	Processors    float32 `json:"powervs_processors"`
 	Region        string  `json:"powervs_region"`
 	ResourceGroup string  `json:"powervs_resource_group"`
 	SSHKey        string  `json:"powervs_ssh_key"`


### PR DESCRIPTION
Given memory on PowerVS is supported as integers, align the type to uint and capture the `terraform.Output` only after successful execution of `terraform.Apply`


This avoids the following from appearing in the logs too.
<img width="626" height="220" alt="image" src="https://github.com/user-attachments/assets/c93bf4a9-2606-4248-80b2-149bb8b24b9d" />
