### PR TITLE
Update updown script to support kubetest2 tf deployer setup changes

### DIFF
--- a/scripts/updown-ibmcloud.sh
+++ b/scripts/updown-ibmcloud.sh
@@ -17,8 +17,10 @@
 #Enable debug logging
 set -o xtrace
 
-# Setup kubetest2 tf deployer
-make install-deployer-tf
+# Build the kubetest2 tf deployer locally and source the other dependencies.
+OUT_DIR=/go/bin WHAT='terraform' make build-deployer-tf download-from-cos
+make download-tf-plugins-from-cos
+make install-ansible
 
 # Fetch latest Kubernetes version
 K8S_BUILD_VERSION=$(curl -s https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)
@@ -37,5 +39,5 @@ kubetest2 tf \
   --retry-on-tf-failure 3 \
   --ignore-destroy-errors \
   --break-kubetest-on-upfail true \
-  --powervs-memory 16 \
+  --powervs-memory 8 --powervs-processors 0.25 \
   --test=ginkgo --  --parallel 30 --test-package-dir ci --test-package-version "${K8S_BUILD_VERSION}" --focus-regex='Pods should be submitted and removed'


### PR DESCRIPTION

This PR updates the `updown-ibmcloud.sh` script to align with recent changes in the kubetest2 TF deployer setup commands introduced [in provider-ibmcloud-test-infra#[91]](https://github.com/kubernetes-sigs/provider-ibmcloud-test-infra/pull/91).

Previously, the `make install-deployer-tf` step installed prebuilt binaries from IBM COS. However, the purpose of the `pull-provider-ibmcloud-test-infra-kubernetes` job is to validate changes in the `provider-ibmcloud-test-infra` repository itself.

Update the updown script to align with the recent kubetest2 tf deployer setup changes introduced in #[36853](https://github.com/kubernetes/test-infra/pull/36853)