### PR TITLE
Migrate to using `ansible_facts` in playbooks

### DIFF
--- a/kubetest2-tf/data/k8s-ansible/group_vars/all
+++ b/kubetest2-tf/data/k8s-ansible/group_vars/all
@@ -93,7 +93,7 @@ flannel_version: v0.28.4
 ##### Bridge CNI Configurations #####
 cni_plugins_version: v1.9.1
 cni_plugins_url: https://github.com/containernetworking/plugins/releases/download
-cni_plugins_tarball: "cni-plugins-linux-{{ ansible_architecture }}-{{ cni_plugins_version }}.tgz"
+cni_plugins_tarball: "cni-plugins-linux-{{ ansible_facts['architecture'] }}-{{ cni_plugins_version }}.tgz"
 
 # NFS server details
 nfs_directory: "/var/nfsshare"

--- a/kubetest2-tf/data/k8s-ansible/install-k8s-ha.yml
+++ b/kubetest2-tf/data/k8s-ansible/install-k8s-ha.yml
@@ -27,7 +27,7 @@
     - workers
   roles:
     - role: set-smt
-      when: ansible_architecture == 'ppc64le'
+      when: ansible_facts['architecture'] == 'ppc64le'
 
 - name: Install networking - calico
   hosts: masters

--- a/kubetest2-tf/data/k8s-ansible/roles/disable-swap-selinux/tasks/main.yml
+++ b/kubetest2-tf/data/k8s-ansible/roles/disable-swap-selinux/tasks/main.yml
@@ -12,4 +12,4 @@
   ansible.posix.selinux:
     state: permissive
     policy: targeted
-  when: ansible_distribution in ['RedHat', 'CentOS']
+  when: ansible_facts['distribution'] in ['RedHat', 'CentOS']

--- a/kubetest2-tf/data/k8s-ansible/roles/download-k8s/tasks/main.yml
+++ b/kubetest2-tf/data/k8s-ansible/roles/download-k8s/tasks/main.yml
@@ -20,7 +20,7 @@
 
 - name: Import control plane component container images
   shell: |
-    export ARCH={{ ansible_architecture }}
+    export ARCH={{ ansible_facts['architecture'] }}
     ctr -n k8s.io images import "/usr/bin/{{ item }}.tar"
     ctr -n k8s.io images ls -q | grep -e {{ item }} | xargs -L 1 -I '{}' /bin/bash -c 'ctr -n k8s.io images tag "{}" "$(echo "{}" | sed s/-'$ARCH':/:/)"'
   with_items:
@@ -32,7 +32,7 @@
 
 - name: Import common container images required for setting up cluster
   shell: |
-    export ARCH={{ ansible_architecture }}
+    export ARCH={{ ansible_facts['architecture'] }}
     ctr -n k8s.io images import "/usr/bin/{{ item }}.tar"
     ctr -n k8s.io images ls -q | grep -e {{ item }} | xargs -L 1 -I '{}' /bin/bash -c 'ctr -n k8s.io images tag "{}" "$(echo "{}" | sed s/-'$ARCH':/:/)"'
   with_items:

--- a/kubetest2-tf/data/k8s-ansible/roles/install-calico/defaults/main.yml
+++ b/kubetest2-tf/data/k8s-ansible/roles/install-calico/defaults/main.yml
@@ -1,1 +1,1 @@
-calico_mtu: "{{  MTU | default(ansible_default_ipv4.mtu) - 60 }}"
+calico_mtu: "{{  MTU | default(ansible_facts['default_ipv4']['mtu']) - 60 }}"

--- a/kubetest2-tf/data/k8s-ansible/roles/install-etcd/tasks/main.yml
+++ b/kubetest2-tf/data/k8s-ansible/roles/install-etcd/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Download and setup etcd
   unarchive:
-    src: "https://storage.googleapis.com/etcd/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-{{ ansible_architecture }}.tar.gz"
+    src: "https://storage.googleapis.com/etcd/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-{{ ansible_facts['architecture'] }}.tar.gz"
     dest: "/usr/local/bin"
     remote_src: yes
     extra_opts:

--- a/kubetest2-tf/data/k8s-ansible/roles/install-k8s/tasks/main.yml
+++ b/kubetest2-tf/data/k8s-ansible/roles/install-k8s/tasks/main.yml
@@ -3,10 +3,10 @@
 # This workaround fixed above failure.
 # Follow up task to remove this in future https://jsw.ibm.com/browse/POWERCLOUD-34
 - name: Disable tx-checksumming on default network interface
-  command: ethtool --offload {{ ansible_default_ipv4['interface'] }} tx-checksumming off
+  command: ethtool --offload {{ ansible_facts['default_ipv4']['interface'] }} tx-checksumming off
   when:
-    - ansible_default_ipv4['interface'] is defined
-    - ansible_architecture == 'ppc64le'
+    - ansible_facts['default_ipv4']['interface'] is defined
+    - ansible_facts['architecture'] == 'ppc64le'
 
 - name: Disable SELinux and disable SWAP in fstab
   include_role:
@@ -25,7 +25,7 @@
       - iproute-tc
       - iptables
     state: present
-  when: ansible_pkg_mgr in ['yum', 'dnf']
+  when: ansible_facts['pkg_mgr'] in ['yum', 'dnf']
 
 - name: Install prereq Ubuntu packages
   apt:
@@ -37,7 +37,7 @@
       - socat
       - iproute2
       - iptables
-  when: ansible_pkg_mgr == 'apt'
+  when: ansible_facts['pkg_mgr'] == 'apt'
 
 - name: Template a kubelet service to /usr/lib/systemd/system/kubelet.service
   template:

--- a/kubetest2-tf/data/k8s-ansible/roles/k8s-node/tasks/main.yml
+++ b/kubetest2-tf/data/k8s-ansible/roles/k8s-node/tasks/main.yml
@@ -16,7 +16,7 @@
       - make
       - gcc
     state: present
-  when: ansible_pkg_mgr in ['yum', 'dnf']
+  when: ansible_facts['pkg_mgr'] in ['yum', 'dnf']
 
 - name: Update apt-get repo/cache and install prereq packages
   apt:
@@ -29,7 +29,7 @@
       - git
       - make
       - gcc
-  when: ansible_pkg_mgr == 'apt'
+  when: ansible_facts['pkg_mgr'] == 'apt'
 
 - name: Capture the commit ID
   set_fact:

--- a/kubetest2-tf/data/k8s-ansible/roles/k8s-ut/tasks/main.yml
+++ b/kubetest2-tf/data/k8s-ansible/roles/k8s-ut/tasks/main.yml
@@ -5,7 +5,7 @@
       - make
       - gcc
     state: present
-  when: ansible_pkg_mgr in ['yum','dnf']
+  when: ansible_facts['pkg_mgr'] in ['yum','dnf']
 
 - name: Update apt-get repo/cache and install prereq packages
   apt:
@@ -19,7 +19,7 @@
       - make
       - gcc
       - jq
-  when: ansible_pkg_mgr == 'apt'
+  when: ansible_facts['pkg_mgr'] == 'apt'
 
 - name: Create a shell script
   copy:

--- a/kubetest2-tf/data/k8s-ansible/roles/reboot-sequentially/tasks/main.yaml
+++ b/kubetest2-tf/data/k8s-ansible/roles/reboot-sequentially/tasks/main.yaml
@@ -57,7 +57,7 @@
     - name: Set desired SMT levels on nodes
       include_role:
         name: set-smt
-      when: ansible_architecture == 'ppc64le' and node_type == "worker"
+      when: ansible_facts['architecture'] == 'ppc64le' and node_type == "worker"
 
     - name: Uncordon the node
       shell: kubectl uncordon {{ node_name.stdout }} --kubeconfig {{ kubeconfig_path }}

--- a/kubetest2-tf/data/k8s-ansible/roles/runtime/tasks/containerd.yaml
+++ b/kubetest2-tf/data/k8s-ansible/roles/runtime/tasks/containerd.yaml
@@ -6,7 +6,7 @@
       - lvm2
     state: present
     disable_gpg_check: true
-  when: ansible_pkg_mgr in ['yum', 'dnf']
+  when: ansible_facts['pkg_mgr'] in ['yum', 'dnf']
 
 - name: Install containerd dependencies
   apt:
@@ -14,11 +14,11 @@
       - lvm2
     state: present
     allow_unauthenticated: true
-  when: ansible_pkg_mgr == 'apt'
+  when: ansible_facts['pkg_mgr'] == 'apt'
 
 - name: Download and set up containerd - {{ containerd_version }}
   unarchive:
-    src: "https://github.com/containerd/containerd/releases/download/v{{ containerd_version }}/containerd-{{ containerd_version }}-linux-{{ ansible_architecture }}.tar.gz"
+    src: "https://github.com/containerd/containerd/releases/download/v{{ containerd_version }}/containerd-{{ containerd_version }}-linux-{{ ansible_facts['architecture'] }}.tar.gz"
     dest: "/usr/local"
     remote_src: yes
   retries: 3

--- a/kubetest2-tf/data/k8s-ansible/roles/runtime/tasks/crio.yaml
+++ b/kubetest2-tf/data/k8s-ansible/roles/runtime/tasks/crio.yaml
@@ -5,7 +5,7 @@
       - conmon
     state: present
     disable_gpg_check: true
-  when: ansible_pkg_mgr in ['yum', 'dnf']
+  when: ansible_facts['pkg_mgr'] in ['yum', 'dnf']
 
 - name: Install CRI-O and dependencies.
   apt:
@@ -13,11 +13,11 @@
       - conmon
     state: present
     allow_unauthenticated: true
-  when: ansible_pkg_mgr == 'apt'
+  when: ansible_facts['pkg_mgr'] == 'apt'
 
 - name: Download CRI-O - {{ crio_version }}
   unarchive:
-    src: "https://storage.googleapis.com/cri-o/artifacts/cri-o.{{ ansible_architecture }}.v{{ crio_version }}.tar.gz"
+    src: "https://storage.googleapis.com/cri-o/artifacts/cri-o.{{ ansible_facts['architecture'] }}.v{{ crio_version }}.tar.gz"
     dest: "/usr/bin/"
     remote_src: yes
     include: cri-o/bin

--- a/kubetest2-tf/data/k8s-ansible/roles/runtime/tasks/main.yaml
+++ b/kubetest2-tf/data/k8s-ansible/roles/runtime/tasks/main.yaml
@@ -37,7 +37,7 @@
         mode: '0644'
     - name: Install crictl - {{ critools_version }}
       unarchive:
-        src: "https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{ critools_version }}/crictl-v{{ critools_version }}-linux-{{ ansible_architecture }}.tar.gz"
+        src: "https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{ critools_version }}/crictl-v{{ critools_version }}-linux-{{ ansible_facts['architecture'] }}.tar.gz"
         dest: "/usr/bin/"
         remote_src: yes
 
@@ -45,18 +45,18 @@
       package:
         name: iptables
         state: present
-      when: ansible_pkg_mgr in ['yum', 'dnf']
+      when: ansible_facts['pkg_mgr'] in ['yum', 'dnf']
 
     - name: Install iptables
       apt:
         force_apt_get: yes
         update_cache: yes
         name: iptables
-      when: ansible_pkg_mgr == 'apt'
+      when: ansible_facts['pkg_mgr'] == 'apt'
 
     - name: Install runc - {{ runc_version }}
       get_url:
-        url: "https://github.com/opencontainers/runc/releases/download/v{{ runc_version }}/runc.{{ ansible_architecture }}"
+        url: "https://github.com/opencontainers/runc/releases/download/v{{ runc_version }}/runc.{{ ansible_facts['architecture'] }}"
         dest: /usr/bin/runc
         mode: '0755'
 

--- a/kubetest2-tf/data/k8s-ansible/roles/runtime/templates/docker/daemon.j2
+++ b/kubetest2-tf/data/k8s-ansible/roles/runtime/templates/docker/daemon.j2
@@ -8,7 +8,7 @@
 "storage-opts": [
   "overlay2.override_kernel_check=true"
 ],
-"mtu": {{ MTU | default(ansible_default_ipv4.mtu) }}
+"mtu": {{ MTU | default(ansible_facts['default_ipv4']['mtu']) }}
 {% if (registry_mirrors is defined) and registry_mirrors -%},
 "registry-mirrors": [ {{ registry_mirrors|map("to_json")|join(", ") }} ]
 {% endif %}

--- a/kubetest2-tf/data/k8s-ansible/roles/setup-networking/tasks/main.yml
+++ b/kubetest2-tf/data/k8s-ansible/roles/setup-networking/tasks/main.yml
@@ -2,7 +2,7 @@
   package:
     name: iptables
     state: present
-  when: node_type == "bastion" and ansible_pkg_mgr in ['yum', 'dnf']
+  when: node_type == "bastion" and ansible_facts['pkg_mgr'] in ['yum', 'dnf']
 
 - name: Configure networks on bastion
   shell: |
@@ -45,7 +45,7 @@
 
 - name: Identify interfaces on the masters and workers associated with private IP
   shell: |
-    dev_uuid=$(grep $(ip a | grep {{ ansible_default_ipv4.address }} | awk '{ print $NF }') <(nmcli -g device,uuid con) | cut -d':' -f2)
+    dev_uuid=$(grep $(ip a | grep {{ ansible_facts['default_ipv4']['address'] }} | awk '{ print $NF }') <(nmcli -g device,uuid con) | cut -d':' -f2)
     nmcli conn modify $dev_uuid ipv4.gateway {{ bastion_private_ip }}
     nmcli conn modify $dev_uuid +ipv4.routes "{{ vpc_cidr }} {{ bastion_private_gateway }}"
     nmcli conn up $dev_uuid

--- a/kubetest2-tf/data/k8s-ansible/roles/update-node-os/tasks/main.yaml
+++ b/kubetest2-tf/data/k8s-ansible/roles/update-node-os/tasks/main.yaml
@@ -1,26 +1,26 @@
 - name: Disable all IBM repositories
   shell: yum-config-manager --disable 'public.dhe.ibm.com*'
-  when: ansible_distribution in ['CentOS', 'RHEL']
+  when: ansible_facts['distribution'] in ['CentOS', 'RedHat']
 
 - name: Update packages and kernel to latest available versions
   package:
     name: '*'
     state: latest
   when: 
-   - ansible_pkg_mgr in ['yum', 'dnf']
+   - ansible_facts['pkg_mgr'] in ['yum', 'dnf']
    - update_os_packages | bool
 
 - name: Update apt cache
   apt:
     update_cache: yes
-  when: ansible_pkg_mgr == 'apt'
+  when: ansible_facts['pkg_mgr'] == 'apt'
 
 - name: Check if kernel-modules-extra is installed
   package_facts:
     manager: auto
   when:
-    - ansible_pkg_mgr in ['yum', 'dnf']
-    - ansible_distribution_major_version | int >= 10
+    - ansible_facts['pkg_mgr'] in ['yum', 'dnf']
+    - ansible_facts['distribution_major_version'] | int >= 10
 
 - name: Install kernel-modules-extra package for br_netfilter module
   package:
@@ -31,12 +31,12 @@
   delay: 60
   until: kmod_extra is succeeded
   when:
-    - ansible_pkg_mgr in ['yum', 'dnf']
-    - ansible_distribution_major_version | int >= 10
+    - ansible_facts['pkg_mgr'] in ['yum', 'dnf']
+    - ansible_facts['distribution_major_version'] | int >= 10
     - "'kernel-modules-extra' not in (ansible_facts.packages | default({}))"
 
 - name: Check if reboot required
   shell: needs-restarting -r
   register: reboot_check
   ignore_errors: yes
-  when: ansible_distribution in ['CentOS', 'RedHat']
+  when: ansible_facts['distribution'] in ['CentOS', 'RedHat']

--- a/kubetest2-tf/data/k8s-ansible/roles/update-pkgs/tasks/main.yml
+++ b/kubetest2-tf/data/k8s-ansible/roles/update-pkgs/tasks/main.yml
@@ -3,19 +3,19 @@
     - name: check username and password are set
       fail:
         msg: "username and password are the mandatory values to execute the playbook for rhel"
-      when:  ansible_distribution == "RedHat" and  username is not defined or password is not defined
+      when:  ansible_facts['distribution'] == "RedHat" and  username is not defined or password is not defined
 
     - name: Register RHEL
       shell: subscription-manager register --username {{ username }} --password {{ password }} --auto-attach
-      when:  ansible_distribution == "RedHat"
+      when:  ansible_facts['distribution'] == "RedHat"
 
 - name: Include packages and OS update tasks
   include_role:
     name: update-node-os
-  when: ansible_distribution in ['CentOS', 'RHEL', 'Ubuntu']
+  when: ansible_facts['distribution'] in ['CentOS', 'RedHat', 'Ubuntu']
 
 - name: Reboot if kernel-modules-extra updated or reboot if necessary
   reboot:
   when:
-    - ansible_distribution in ['CentOS', 'RedHat']
+    - ansible_facts['distribution'] in ['CentOS', 'RedHat']
     - kmod_extra.changed or reboot_check.rc == 1

--- a/kubetest2-tf/deployer/deployer.go
+++ b/kubetest2-tf/deployer/deployer.go
@@ -270,7 +270,6 @@ func (d *deployer) Up() error {
 		klog.Errorf("Error while running terraform output. Error: %v", err)
 		return err
 	}
-	fmt.Println("Terraform output: %v\n", tfMetaOutput)
 	var tfOutput map[string][]interface{}
 	data, err := json.Marshal(tfMetaOutput)
 	if err != nil {


### PR DESCRIPTION
Mitigates:
```
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, 
top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.
```