### PR TITLE
Cross build enablement for kubetest2-tf, New Make targets for tar/untar tf plugins, Changes to ansible install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+GOOS:=$(or $(GOOS),linux)
+GOARCH:=$(or $(GOARCH),$(shell uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/'))
+
 # kubetest2-tf targets
 install-deployer-tf:
-	$(MAKE) -C kubetest2-tf/ install-deployer-tf
+	$(MAKE) -C kubetest2-tf/ install-deployer-tf GOARCH="$(GOARCH)" GOOS="$(GOOS)"
 
 build-deployer-tf:
-	$(MAKE) -C kubetest2-tf/ build-deployer-tf
+	$(MAKE) -C kubetest2-tf/ build-deployer-tf GOARCH="$(GOARCH)" GOOS="$(GOOS)"
 
 install-prereq:
 	$(MAKE) -C kubetest2-tf/ install-prereq
@@ -29,10 +32,16 @@ setup-tf:
 	$(MAKE) -C kubetest2-tf/ setup-tf
 
 build-tf-and-plugins:
-	$(MAKE) -C kubetest2-tf/ build-tf-and-plugins
+	$(MAKE) -C kubetest2-tf/ build-tf-and-plugins GOARCH="$(GOARCH)" GOOS="$(GOOS)"
+
+generate-tar-tf-plugins:
+	$(MAKE) -C kubetest2-tf/ generate-tar-tf-plugins GOARCH="$(GOARCH)" GOOS="$(GOOS)"
 
 download-tf-plugins-from-cos:
-	$(MAKE) -C kubetest2-tf/ download-tf-plugins-from-cos
+	$(MAKE) -C kubetest2-tf/ download-tf-plugins-from-cos GOARCH="$(GOARCH)"
+
+download-untar-tf-plugins-from-cos:
+	$(MAKE) -C kubetest2-tf/ download-untar-tf-plugins-from-cos GOARCH="$(GOARCH)"
 
 download-from-cos:
 	$(MAKE) -C kubetest2-tf/ download-from-cos WHAT="$(WHAT)"

--- a/kubetest2-tf/Makefile
+++ b/kubetest2-tf/Makefile
@@ -34,6 +34,11 @@ INSTALL?=install
 INSTALL_DIR?=$(shell $(REPO_ROOT)/hack/goinstalldir.sh)
 # the output binary name, overridden when cross compiling
 BINARY_NAME=kubetest2-tf
+# Multi-arch support: defaults to linux with architecture from uname -m, override GOOS and GOARCH for other targets
+# Examples: make build-deployer-tf GOOS=linux GOARCH=amd64
+#           make build-deployer-tf GOOS=darwin GOARCH=arm64
+GOOS?=linux
+GOARCH?=$(shell uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')
 BUILD_FLAGS=-trimpath -ldflags="-s -w -buildid= -X=sigs.k8s.io/provider-ibmcloud-test-infra/kubetest2-tf/deployer/deployer.GitTag=$(COMMIT)"
 # IBM Cloud COS bucket configuration for binary downloads/uploads
 COS_REGION?=us
@@ -63,48 +68,68 @@ setup-tf: ## Install Terraform
 .PHONY: setup-tf
 
 build-deployer-tf: ## Build the kubetest2-tf deployer binary
-	@echo "Building $(BINARY_NAME)..."
+	@echo "Building $(BINARY_NAME) for $(GOOS)/$(GOARCH)..."
 	@mkdir -p $(OUT_DIR)
-	go build $(BUILD_FLAGS) -o $(OUT_DIR)/$(BINARY_NAME) .
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(BUILD_FLAGS) -o $(OUT_DIR)/$(BINARY_NAME) .
 .PHONY: build-deployer-tf
 
-build-tf-and-plugins: ## Build Terraform binary and plugins for ppc64le
-	@echo "Building terraform binary and plugins..."
-	@mkdir -p $(OUT_DIR)
-	@mkdir -p $(OUT_DIR)/plugins
-	TF_INSTALL_DIR=$(OUT_DIR) TF_PLUGIN_PATH=$(OUT_DIR)/plugins ./hack/terraform_install.sh
+build-tf-and-plugins: ## Build Terraform binary and plugins
+	@echo "Building terraform binary and plugins for $(GOOS)/$(GOARCH)..."
+	@mkdir -p $(OUT_DIR)/plugins/registry.terraform.io
+	GOOS=$(GOOS) GOARCH=$(GOARCH) TF_INSTALL_DIR=$(OUT_DIR) TF_PLUGIN_PATH=$(OUT_DIR)/plugins/registry.terraform.io ./hack/terraform_install.sh
 	@echo "Terraform and plugins successfully built and moved to $(OUT_DIR)"
 .PHONY: build-tf-and-plugins
 
-download-tf-plugins-from-cos: ## Download Terraform plugins from IBM Cloud COS
+download-tf-plugins-from-cos: ## Download Terraform plugins from IBM Cloud COS (individual files)
 	@echo "Downloading terraform plugins from IBM Cloud COS..."
-	@ARCH=$$(uname -m); \
-	. $(REPO_ROOT)/hack/terraform_versions.env; \
+	@. $(REPO_ROOT)/hack/terraform_versions.env; \
 	TF_PLUGIN_PATH="$$HOME/.terraform.d/plugins/registry.terraform.io"; \
-	DOWNLOAD_URL=$(COS_BUCKET_URL)/plugins/IBM-Cloud/ibm/$$TERRAFORM_PROVIDER_IBM_VERSION/linux_$$ARCH/terraform-provider-ibm; \
-	echo "Downloading terraform-provider-ibm for $$ARCH from $$DOWNLOAD_URL"; \
-	mkdir -p "$$TF_PLUGIN_PATH/IBM-Cloud/ibm/$$TERRAFORM_PROVIDER_IBM_VERSION/linux_$$ARCH"; \
-	if ! curl -fsSL -o "$$TF_PLUGIN_PATH/IBM-Cloud/ibm/$$TERRAFORM_PROVIDER_IBM_VERSION/linux_$$ARCH/terraform-provider-ibm" \
+	DOWNLOAD_URL=$(COS_BUCKET_URL)/plugins/IBM-Cloud/ibm/$$TERRAFORM_PROVIDER_IBM_VERSION/linux_$(GOARCH)/terraform-provider-ibm; \
+	echo "Downloading terraform-provider-ibm for $(GOARCH) from $$DOWNLOAD_URL"; \
+	mkdir -p "$$TF_PLUGIN_PATH/IBM-Cloud/ibm/$$TERRAFORM_PROVIDER_IBM_VERSION/linux_$(GOARCH)"; \
+	if ! curl -fsSL -o "$$TF_PLUGIN_PATH/IBM-Cloud/ibm/$$TERRAFORM_PROVIDER_IBM_VERSION/linux_$(GOARCH)/terraform-provider-ibm" \
 		"$$DOWNLOAD_URL"; then \
 		echo "Error: Failed to download from $$DOWNLOAD_URL"; \
 		exit 1; \
 	fi; \
-	chmod +x "$$TF_PLUGIN_PATH/IBM-Cloud/ibm/$$TERRAFORM_PROVIDER_IBM_VERSION/linux_$$ARCH/terraform-provider-ibm"; \
-	DOWNLOAD_URL=$(COS_BUCKET_URL)/plugins/hashicorp/null/$$TERRAFORM_PROVIDER_NULL_VERSION/linux_$$ARCH/terraform-provider-null; \
-	echo "Downloading terraform-provider-null for $$ARCH from $$DOWNLOAD_URL"; \
-	mkdir -p "$$TF_PLUGIN_PATH/hashicorp/null/$$TERRAFORM_PROVIDER_NULL_VERSION/linux_$$ARCH"; \
-	if ! curl -fsSL -o "$$TF_PLUGIN_PATH/hashicorp/null/$$TERRAFORM_PROVIDER_NULL_VERSION/linux_$$ARCH/terraform-provider-null" \
+	chmod +x "$$TF_PLUGIN_PATH/IBM-Cloud/ibm/$$TERRAFORM_PROVIDER_IBM_VERSION/linux_$(GOARCH)/terraform-provider-ibm"; \
+	DOWNLOAD_URL=$(COS_BUCKET_URL)/plugins/hashicorp/null/$$TERRAFORM_PROVIDER_NULL_VERSION/linux_$(GOARCH)/terraform-provider-null; \
+	echo "Downloading terraform-provider-null for $(GOARCH) from $$DOWNLOAD_URL"; \
+	mkdir -p "$$TF_PLUGIN_PATH/hashicorp/null/$$TERRAFORM_PROVIDER_NULL_VERSION/linux_$(GOARCH)"; \
+	if ! curl -fsSL -o "$$TF_PLUGIN_PATH/hashicorp/null/$$TERRAFORM_PROVIDER_NULL_VERSION/linux_$(GOARCH)/terraform-provider-null" \
 		"$$DOWNLOAD_URL"; then \
 		echo "Error: Failed to download from $$DOWNLOAD_URL"; \
 		exit 1; \
 	fi; \
-	chmod +x "$$TF_PLUGIN_PATH/hashicorp/null/$$TERRAFORM_PROVIDER_NULL_VERSION/linux_$$ARCH/terraform-provider-null"; \
+	chmod +x "$$TF_PLUGIN_PATH/hashicorp/null/$$TERRAFORM_PROVIDER_NULL_VERSION/linux_$(GOARCH)/terraform-provider-null"; \
 	echo "Successfully downloaded and installed terraform plugins to $$TF_PLUGIN_PATH"
 .PHONY: download-tf-plugins-from-cos
 
+generate-tar-tf-plugins: build-tf-and-plugins ## Build and create tarball of Terraform plugins with full path structure
+	@TARBALL_NAME="terraform-plugins-$(GOOS)-$(GOARCH).tar.gz"; \
+	echo "Packaging plugins from $(OUT_DIR)/plugins into $$TARBALL_NAME"; \
+	cd $(OUT_DIR) && tar -czf $$TARBALL_NAME plugins && \
+	echo "Successfully created $(OUT_DIR)/$$TARBALL_NAME"
+.PHONY: generate-tar-tf-plugins
+
+download-untar-tf-plugins-from-cos:
+	@ARCH=$$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/'); \
+	echo "Downloading terraform plugins (IBM Cloud and null providers) tarball from IBM Cloud COS for $$ARCH..."; \
+	TF_PLUGIN_DIR="$$HOME/.terraform.d"; \
+	TARBALL_NAME="terraform-plugins-linux-$$ARCH.tar.gz"; \
+	DOWNLOAD_URL=$(COS_BUCKET_URL)/$$TARBALL_NAME; \
+	echo "Downloading $$TARBALL_NAME from $$DOWNLOAD_URL"; \
+	mkdir -p "$$HOME/.terraform.d"; \
+	if ! curl -fsSL "$$DOWNLOAD_URL" | tar -xzf - -C "$$HOME/.terraform.d"; then \
+		echo "Error: Failed to download or extract from $$DOWNLOAD_URL"; \
+		exit 1; \
+	fi
+	@echo "Successfully downloaded and extracted terraform plugins to $$HOME/.terraform.d/plugins/registry.terraform.io"
+.PHONY: download-untar-tf-plugins-from-cos
+
 
 install-deployer-tf: ## Install kubetest2-tf deployer from source or downloads prebuilt binaries from COS
-	@if [ "$$(uname -m)" = "ppc64le" ]; then \
+	@if [ "$(GOARCH)" = "ppc64le" ]; then \
 		$(MAKE) install-ansible; \
 		$(MAKE) download-from-cos WHAT='kubetest2-tf terraform'; \
 		$(MAKE) download-tf-plugins-from-cos; \

--- a/kubetest2-tf/hack/ansible_install.sh
+++ b/kubetest2-tf/hack/ansible_install.sh
@@ -18,10 +18,42 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+detect_os() {
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        OS=$ID
+    elif [ -f /etc/redhat-release ]; then
+        OS="rhel"
+    else
+        echo "Error: Unable to detect OS"
+        exit 1
+    fi
+}
+
 install_ansible() {
     echo "Installing ansible..."
-    ##Install ansible required to bring up k8s cluster on infra
-    apt-get update && pip install --break-system-packages ansible
+    detect_os
+
+    case "$OS" in
+        ubuntu|debian)
+            ##Install ansible required to bring up k8s cluster on infra
+            apt-get update && pip install --break-system-packages ansible
+            ;;
+        rhel|centos)
+            echo "Detected RHEL/CentOS system"
+            if command -v dnf >/dev/null 2>&1; then
+                dnf install -y python3-pip
+            else
+                yum install -y python3-pip
+            fi
+            pip3 install ansible
+            ;;
+        *)
+            echo "Error: Unsupported OS: $OS"
+            echo "This script supports Ubuntu/Debian and RHEL/CentOS only"
+            exit 1
+            ;;
+    esac
 }
 
 # Call if ansible not found

--- a/kubetest2-tf/hack/terraform_install.sh
+++ b/kubetest2-tf/hack/terraform_install.sh
@@ -27,67 +27,76 @@ GO_LDFLAGS="-s -w"
 TF_INSTALL_DIR="${TF_INSTALL_DIR:-/usr/local/bin}"
 TF_PLUGIN_PATH="${TF_PLUGIN_PATH:-$HOME/.terraform.d/plugins/registry.terraform.io}"
 
-install_terraform(){
-    if [[ ! -z $(command -v terraform) ]]; then
-        echo "terraform already present"
-    else
-        cd /tmp
-        curl -fsSL https://github.com/hashicorp/terraform/archive/refs/tags/v${TF_VERSION}.zip -o ./terraform.zip
-        unzip -o ./terraform.zip  >/dev/null 2>&1
-        rm -f ./terraform.zip
-        cd terraform-${TF_VERSION}
-        go build -ldflags="${GO_LDFLAGS}" .
-        mkdir -p "${TF_INSTALL_DIR}"
-        cp terraform "${TF_INSTALL_DIR}/"
-    fi
+GOARCH="${GOARCH:-$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')}"
+GOOS="${GOOS:-$(uname -s | tr '[:upper:]' '[:lower:]')}"
+
+place_terraform_binary(){
+    mkdir -p "${TF_INSTALL_DIR}"
+    cp terraform "${TF_INSTALL_DIR}/"
+    rm -f ./terraform.zip
 }
 
-install_terraform_x86(){
-    if [[ ! -z $(command -v terraform) ]]; then
-        echo "terraform already present"
-    else
-        cd /tmp
-        curl -fsSL https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip -o ./terraform.zip
-        unzip -o ./terraform.zip  >/dev/null 2>&1
-        rm -f ./terraform.zip
-        mkdir -p "${TF_INSTALL_DIR}"
-        cp terraform "${TF_INSTALL_DIR}/"
-    fi
+build_and_install_terraform(){
+    cd /tmp
+    curl -fsSL https://github.com/hashicorp/terraform/archive/refs/tags/v${TF_VERSION}.zip -o ./terraform.zip
+    unzip -o ./terraform.zip >/dev/null 2>&1
+    cd terraform-${TF_VERSION}
+    CGO_ENABLED=0 go build -ldflags="${GO_LDFLAGS}" .
+    place_terraform_binary
+}
+
+download_terraform_from_source(){
+    cd /tmp
+    curl -fsSL https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_${GOOS}_${GOARCH}.zip -o ./terraform.zip
+    unzip -o ./terraform.zip >/dev/null 2>&1
+    place_terraform_binary
 }
 
 build_ibm_provider(){
-    if [[ ! -f "${TF_PLUGIN_PATH}/IBM-Cloud/ibm/${TERRAFORM_PROVIDER_IBM_VERSION}/linux_${ARCH}/terraform-provider-ibm" ]]; then
+    if [[ ! -f "${TF_PLUGIN_PATH}/IBM-Cloud/ibm/${TERRAFORM_PROVIDER_IBM_VERSION}/${GOOS}_${GOARCH}/terraform-provider-ibm" ]]; then
+            echo "Building IBM Cloud provider v${TERRAFORM_PROVIDER_IBM_VERSION} for ${GOOS}/${GOARCH}"
         cd /tmp
         curl -fsSL https://github.com/IBM-Cloud/terraform-provider-ibm/archive/refs/tags/v${TERRAFORM_PROVIDER_IBM_VERSION}.zip -o ./terraform-provider-ibm.zip
         unzip -o ./terraform-provider-ibm.zip  >/dev/null 2>&1
         rm -f ./terraform-provider-ibm.zip
         cd terraform-provider-ibm-${TERRAFORM_PROVIDER_IBM_VERSION}
-        go build -ldflags="${GO_LDFLAGS}" .
-        mkdir -p ${TF_PLUGIN_PATH}/IBM-Cloud/ibm/${TERRAFORM_PROVIDER_IBM_VERSION}/linux_`go env GOARCH`
-        cp -f terraform-provider-ibm ${TF_PLUGIN_PATH}/IBM-Cloud/ibm/${TERRAFORM_PROVIDER_IBM_VERSION}/linux_`go env GOARCH`
+        GOOS=${GOOS} GOARCH=${GOARCH} go build -v -ldflags="${GO_LDFLAGS}" .
+        mkdir -p ${TF_PLUGIN_PATH}/IBM-Cloud/ibm/${TERRAFORM_PROVIDER_IBM_VERSION}/${GOOS}_${GOARCH}
+        cp -f terraform-provider-ibm ${TF_PLUGIN_PATH}/IBM-Cloud/ibm/${TERRAFORM_PROVIDER_IBM_VERSION}/${GOOS}_${GOARCH}
+    else
+        echo "IBM Cloud provider v${TERRAFORM_PROVIDER_IBM_VERSION} already exists at ${TF_PLUGIN_PATH}/IBM-Cloud/ibm/${TERRAFORM_PROVIDER_IBM_VERSION}/${GOOS}_${GOARCH}"
     fi
 }
 
 build_null_provider(){
-    if [[ ! -f "${TF_PLUGIN_PATH}/hashicorp/null/${TERRAFORM_PROVIDER_NULL_VERSION}/linux_${ARCH}/terraform-provider-null" ]]; then
-        echo "building null provider"
+    if [[ ! -f "${TF_PLUGIN_PATH}/hashicorp/null/${TERRAFORM_PROVIDER_NULL_VERSION}/${GOOS}_${GOARCH}/terraform-provider-null" ]]; then
+        echo "Building null provider v${TERRAFORM_PROVIDER_NULL_VERSION} for ${GOOS}/${GOARCH}"
         cd /tmp
         curl -fsSL https://github.com/hashicorp/terraform-provider-null/archive/refs/tags/v${TERRAFORM_PROVIDER_NULL_VERSION}.zip -o ./terraform-provider-null.zip
         unzip -o ./terraform-provider-null.zip  >/dev/null 2>&1
         rm -f ./terraform-provider-null.zip
         cd terraform-provider-null-${TERRAFORM_PROVIDER_NULL_VERSION}
-        go build -ldflags="${GO_LDFLAGS}" .
-        mkdir -p ${TF_PLUGIN_PATH}/hashicorp/null/${TERRAFORM_PROVIDER_NULL_VERSION}/linux_`go env GOARCH`
-        cp terraform-provider-null ${TF_PLUGIN_PATH}/hashicorp/null/${TERRAFORM_PROVIDER_NULL_VERSION}/linux_`go env GOARCH`
+        GOOS=${GOOS} GOARCH=${GOARCH} go build -v -ldflags="${GO_LDFLAGS}" .
+        mkdir -p ${TF_PLUGIN_PATH}/hashicorp/null/${TERRAFORM_PROVIDER_NULL_VERSION}/${GOOS}_${GOARCH}
+        cp terraform-provider-null ${TF_PLUGIN_PATH}/hashicorp/null/${TERRAFORM_PROVIDER_NULL_VERSION}/${GOOS}_${GOARCH}
+    else
+        echo "null provider v${TERRAFORM_PROVIDER_NULL_VERSION} already exists at ${TF_PLUGIN_PATH}/hashicorp/null/${TERRAFORM_PROVIDER_NULL_VERSION}/${GOOS}_${GOARCH}"
     fi
 }
 
-ARCH=$(uname -m)
-
-if [[ "${ARCH}" == "ppc64le" || "${ARCH}" == "s390x" ]]; then
-    install_terraform
-    build_ibm_provider
-    build_null_provider
-elif [[ "${ARCH}" == "x86_64" ]]; then
-    install_terraform_x86
+# Install Terraform if not already present
+if [[ -f "${TF_INSTALL_DIR}/terraform" ]]; then
+    echo "Terraform already present at ${TF_INSTALL_DIR}/terraform"
+else
+    if [[ "${GOARCH}" == "ppc64le" || "${GOARCH}" == "s390x" ]]; then
+        echo "Building Terraform v${TF_VERSION} from source for ${GOOS}/${GOARCH}"
+        build_and_install_terraform
+    else
+        echo "Downloading Terraform v${TF_VERSION} for ${GOOS}/${GOARCH}"
+        download_terraform_from_source
+    fi
 fi
+
+# Build providers for all architectures
+build_ibm_provider
+build_null_provider


### PR DESCRIPTION
1. Updated the Makefile to introduce new targets such as `generate-tar-tf-plugins` and `download-untar-tf-plugins-from-cos`. These changes enable storing Terraform plugin artifacts as tar files in COS, instead of using nested directory structures when running `push-to-cos`.

2. Improved the `Ansible` setup to detect the underlying OS and use the appropriate package manager accordingly.

3. Enabled cross-build support for `kubetest2-tf` for both amd64 and arm64 architectures.