### PR TITLE
Bump k8s dependencies to latest available versions

### DIFF
--- a/kubetest2-tf/data/k8s-ansible/group_vars/all
+++ b/kubetest2-tf/data/k8s-ansible/group_vars/all
@@ -21,13 +21,13 @@ kubeconfig_path: kubeconfig
 
 ##### Runtime Configurations #####
 # cri-tools version
-critools_version: 1.35.0
+critools_version: 1.36.0
 runc_version: 1.4.2
 # valid runtimes: containerd [default], crio.
 runtime: containerd
 container_runtime_test_handler: false
-containerd_version: 2.2.3
-crio_version: 1.35.2
+containerd_version: 2.3.1
+crio_version: 1.35.3
 pause_container_image: registry.k8s.io/pause:3.10.1
 
 cgroup_driver: systemd
@@ -85,7 +85,7 @@ calico_installation_type: manifest
 prepull_images: []
 
 ##### ETCD version #####
-etcd_version: v3.6.10
+etcd_version: v3.6.11
 
 ##### Flannel configurations #####
 flannel_version: v0.28.4

--- a/scripts/kubeadm-install.sh
+++ b/scripts/kubeadm-install.sh
@@ -60,9 +60,9 @@ set -o noglob
 #
 # Version Configuration:
 #   INSTALL_K8S_VERSION             - Kubernetes version (e.g., 1.28.0, 1.29.0)
-#   INSTALL_K8S_CONTAINERD_VERSION  - Containerd version (default: 2.2.2)
-#   INSTALL_K8S_RUNC_VERSION        - Runc version (default: 1.4.1)
-#   INSTALL_K8S_CRICTL_VERSION      - Crictl version (default: 1.35.0)
+#   INSTALL_K8S_CONTAINERD_VERSION  - Containerd version (default: 2.3.1)
+#   INSTALL_K8S_RUNC_VERSION        - Runc version (default: 1.4.2)
+#   INSTALL_K8S_CRICTL_VERSION      - Crictl version (default: 1.36.0)
 #   INSTALL_K8S_CALICO_VERSION      - Calico version (default: v3.27.5)
 #
 # Cluster Configuration:
@@ -233,13 +233,13 @@ determine_k8s_version() {
 # --- define needed environment variables ---
 setup_versions() {
     # --- set containerd version (preserve if already set from bundle) ---
-    CONTAINERD_VERSION=${CONTAINERD_VERSION:-${INSTALL_K8S_CONTAINERD_VERSION:-2.2.2}}
+    CONTAINERD_VERSION=${CONTAINERD_VERSION:-${INSTALL_K8S_CONTAINERD_VERSION:-2.3.1}}
     
     # --- set runc version (preserve if already set from bundle) ---
-    RUNC_VERSION=${RUNC_VERSION:-${INSTALL_K8S_RUNC_VERSION:-1.4.1}}
+    RUNC_VERSION=${RUNC_VERSION:-${INSTALL_K8S_RUNC_VERSION:-1.4.2}}
     
     # --- set crictl version (preserve if already set from bundle) ---
-    CRICTL_VERSION=${CRICTL_VERSION:-${INSTALL_K8S_CRICTL_VERSION:-1.35.0}}
+    CRICTL_VERSION=${CRICTL_VERSION:-${INSTALL_K8S_CRICTL_VERSION:-1.36.0}}
     
     # --- set kubernetes version (preserve if already set from bundle) ---
     K8S_VERSION=${K8S_VERSION:-${INSTALL_K8S_VERSION:-}}


### PR DESCRIPTION
Bumps the following dependencies 
| Component | Previous Version | New Version |
|-----------|-----------------|-------------|
| critools | 1.35.0 | 1.36.0 |
| containerd | 2.2.3 | 2.3.1 |
| crio | 1.35.2 | 1.35.3 |
| etcd | v3.6.10 | v3.6.11 |

This PR resolves an issue in airgapped deployments where containerd v2.2.3 defaulted to using pause:3.10.1 for pod sandbox creation. As the air-gap bundle only included pause:3.10.2 to match Kubernetes, pod deployment failed due to the missing 3.10.1 image.

Bumping containerd updates its default configuration to use pause:3.10.2, aligning the sandbox image across both Kubernetes and the container runtime.
