### PR TITLE
Fix pause image version mismatch in air-gapped Kubernetes installations

### DIFF
--- a/scripts/kubeadm-install.sh
+++ b/scripts/kubeadm-install.sh
@@ -866,6 +866,21 @@ install_containerd() {
     # Enable SystemdCgroup
     $SUDO sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
     
+    # Configure pause image in air-gapped mode
+    # Extract pause image from bundle's k8s-images.txt and update containerd config
+    if [ -f "${AIRGAP_BUNDLE_DIR}/images/k8s-images.txt" ]; then
+        info "Extracting pause image from air-gapped bundle..."
+        PAUSE_IMAGE=$(grep -m1 'pause:' "${AIRGAP_BUNDLE_DIR}/images/k8s-images.txt")
+        if [ -n "${PAUSE_IMAGE}" ]; then
+            info "Configuring pause image in containerd: ${PAUSE_IMAGE}"
+            # Replace the default sandbox (pause) image in containerd config with the version from kubeadm
+            # This prevents image pull failures in air-gapped environments due to version mismatches
+            $SUDO sed -i "s|sandbox = .*|sandbox = \"${PAUSE_IMAGE}\"|g" /etc/containerd/config.toml
+        else
+            warn "Could not find pause image in bundle's k8s-images.txt"
+        fi
+    fi
+
     # Create containerd systemd service
     info "Creating containerd systemd service"
     create_containerd_service_content | $SUDO tee /etc/systemd/system/containerd.service >/dev/null

--- a/scripts/kubeadm-install.sh
+++ b/scripts/kubeadm-install.sh
@@ -866,19 +866,20 @@ install_containerd() {
     # Enable SystemdCgroup
     $SUDO sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
     
-    # Configure pause image in air-gapped mode
-    # Extract pause image from bundle's k8s-images.txt and update containerd config
-    if [ -f "${AIRGAP_BUNDLE_DIR}/images/k8s-images.txt" ]; then
-        info "Extracting pause image from air-gapped bundle..."
-        PAUSE_IMAGE=$(grep -m1 'pause:' "${AIRGAP_BUNDLE_DIR}/images/k8s-images.txt")
-        if [ -n "${PAUSE_IMAGE}" ]; then
-            info "Configuring pause image in containerd: ${PAUSE_IMAGE}"
-            # Replace the default sandbox (pause) image in containerd config with the version from kubeadm
-            # This prevents image pull failures in air-gapped environments due to version mismatches
-            $SUDO sed -i "s|sandbox = .*|sandbox = \"${PAUSE_IMAGE}\"|g" /etc/containerd/config.toml
-        else
-            warn "Could not find pause image in bundle's k8s-images.txt"
-        fi
+    # Configure pause image to match kubeadm's expected version
+    # This prevents image pull failures due to version mismatches between containerd and kubeadm
+    PAUSE_IMAGE=""
+
+    if command -v kubeadm >/dev/null 2>&1; then
+        info "Querying kubeadm for pause image version..."
+        PAUSE_IMAGE=$(kubeadm config images list ${K8S_VERSION:+--kubernetes-version="${K8S_VERSION}"} 2>/dev/null | grep -m1 'pause:' || echo "")
+    fi
+
+    if [ -n "${PAUSE_IMAGE}" ]; then
+        info "Configuring sandbox image in containerd's config.toml to ${PAUSE_IMAGE}"
+        $SUDO sed -i "s|sandbox = .*|sandbox = \"${PAUSE_IMAGE}\"|g" /etc/containerd/config.toml
+    else
+        warn "Could not determine pause image from kubeadm (command missing or failed), using containerd default"
     fi
 
     # Create containerd systemd service
@@ -1455,9 +1456,9 @@ eval set -- $(escape "${INSTALL_K8S_EXEC}") $(quote "$@")
     disable_swap
     load_kernel_modules
     configure_sysctl
-    install_container_runtime
     install_crictl
     install_kubernetes_packages
+    install_container_runtime
     configure_firewall
     
     if [ "${CMD_K8S}" = "init" ]; then


### PR DESCRIPTION
This PR introduces changes to automatically configure containerd to use the exact pause image version bundled with Kubernetes during air-gapped installations.

Validated with containerd 2.2.2 and kubernetes 1.36.1, which reported this issue.
```
[INFO]  Extracting pause image from air-gapped bundle...
[INFO]  Configuring pause image in containerd: registry.k8s.io/pause:3.10.2
[INFO]  Creating containerd systemd service
Created symlink /etc/systemd/system/multi-user.target.wants/containerd.service → /etc/systemd/system/containerd.service.
```

```
[root@kishen-airgap ~]# cat /etc/containerd/config.toml | grep sandbox
      sandbox = "registry.k8s.io/pause:3.10.2"
      
[root@kishen-airgap ~]# containerd --version
containerd github.com/containerd/containerd/v2 v2.2.2 301b2dac98f15c27117da5c8af12118a041a31d9

[root@kishen-airgap ~]# kubectl version
Client Version: v1.36.1
Kustomize Version: v5.8.1
Server Version: v1.36.1

[root@kishen-airgap ~]# kubectl get pods -A
NAMESPACE     NAME                                                           READY   STATUS    RESTARTS   AGE
kube-system   calico-kube-controllers-6cccb47d69-2msmf                       1/1     Running   0          2m58s
kube-system   calico-node-ll772                                              1/1     Running   0          2m58s
kube-system   coredns-589f44dc88-9mwwt                                       1/1     Running   0          19s
kube-system   coredns-589f44dc88-xknm6                                       1/1     Running   0          19s
kube-system   etcd-kishen-airgap.pokprv.stglabs.ibm.com                      1/1     Running   1          3m41s
kube-system   kube-apiserver-kishen-airgap.pokprv.stglabs.ibm.com            1/1     Running   1          3m41s
kube-system   kube-controller-manager-kishen-airgap.pokprv.stglabs.ibm.com   1/1     Running   1          3m41s
kube-system   kube-proxy-gp8dn                                               1/1     Running   0          3m33s
kube-system   kube-scheduler-kishen-airgap.pokprv.stglabs.ibm.com            1/1     Running   1          3m43s
```


Fixes: #109