### PR TITLE
Use resource-group-id for vpc TF resources

### DIFF
--- a/kubetest2-tf/data/vpc/main.tf
+++ b/kubetest2-tf/data/vpc/main.tf
@@ -1,7 +1,3 @@
-data "ibm_resource_group" "default_group" {
-  name = var.vpc_resource_group
-}
-
 data "ibm_is_image" "node_image" {
   name = var.node_image
 }
@@ -15,7 +11,7 @@ module "vpc" {
   vpc_name       = var.vpc_name
   cluster_name   = var.cluster_name
   zone           = var.vpc_zone
-  resource_group = data.ibm_resource_group.default_group.id
+  resource_group = var.vpc_resource_group
 }
 
 locals {
@@ -30,7 +26,7 @@ resource "ibm_is_instance_template" "node_template" {
   profile        = var.node_profile
   vpc            = local.vpc_id
   zone           = var.vpc_zone
-  resource_group = data.ibm_resource_group.default_group.id
+  resource_group = var.vpc_resource_group
   keys           = [data.ibm_is_ssh_key.ssh_key.id]
 
   primary_network_interface {
@@ -62,7 +58,7 @@ module "master" {
   source                    = "./node"
   node_name                 = "${var.cluster_name}-master"
   node_instance_template_id = ibm_is_instance_template.node_template.id
-  resource_group            = data.ibm_resource_group.default_group.id
+  resource_group            = var.vpc_resource_group
   subnet_id                 = local.subnet_id
   security_group_id         = local.security_group_id
 }
@@ -72,7 +68,7 @@ module "workers" {
   count                     = var.workers_count
   node_name                 = "${var.cluster_name}-worker-${count.index}"
   node_instance_template_id = ibm_is_instance_template.node_template.id
-  resource_group            = data.ibm_resource_group.default_group.id
+  resource_group            = var.vpc_resource_group
   subnet_id                 = local.subnet_id
   security_group_id         = local.security_group_id
 }

--- a/kubetest2-tf/data/vpc/outputs.tf
+++ b/kubetest2-tf/data/vpc/outputs.tf
@@ -4,7 +4,7 @@ output "subnet_id" { value = local.subnet_id }
 output "security_group_id" { value = local.security_group_id }
 output "region" { value = var.vpc_region }
 output "zone" { value = var.vpc_zone }
-output "resource_group_id" { value = data.ibm_resource_group.default_group.id }
+output "resource_group_id" { value = var.vpc_resource_group }
 output "masters" {
   value       = module.master[*].public_ip
   description = "k8s master node IP addresses"

--- a/kubetest2-tf/data/vpc/variables.tf
+++ b/kubetest2-tf/data/vpc/variables.tf
@@ -3,7 +3,8 @@ variable "vpc_api_key" {
 }
 
 variable "vpc_resource_group" {
-  default = "default"
+  description = "IBM Cloud resource group ID"
+  default     = ""
 }
 
 variable "vpc_ssh_key" {}

--- a/kubetest2-tf/deployer/deployer.go
+++ b/kubetest2-tf/deployer/deployer.go
@@ -147,12 +147,15 @@ func (d *deployer) initialize() error {
 		needBoskos := false
 		switch d.TargetProvider {
 		case "vpc":
-			needBoskos = vpc.VPCProvider.Region == "" || vpc.VPCProvider.Zone == "" || vpc.VPCProvider.ResourceGroup == ""
+			needBoskos = vpc.VPCProvider.Region == "" || vpc.VPCProvider.Zone == ""
 		case "powervs":
 			needBoskos = powervs.PowerVSProvider.Zone == "" || powervs.PowerVSProvider.Region == "" || powervs.PowerVSProvider.ServiceID == ""
 		}
 		if needBoskos {
 			klog.V(1).Info("No proper Resource detail provided, acquiring from Boskos")
+			if d.TargetProvider == "vpc" {
+				d.BoskosResourceType = "vpc-service"
+			}
 
 			boskosClient, err := boskos.NewClient(d.BoskosLocation)
 			if err != nil {

--- a/kubetest2-tf/pkg/providers/vpc/vpc.go
+++ b/kubetest2-tf/pkg/providers/vpc/vpc.go
@@ -47,7 +47,7 @@ func (p *Provider) BindFlags(flags *pflag.FlagSet) {
 		&p.Zone, "vpc-zone", "", "IBM Cloud VPC zone name",
 	)
 	flags.StringVar(
-		&p.ResourceGroup, "vpc-resource-group", "Default", "IBM Cloud resource group name(command: ibmcloud resource groups)",
+		&p.ResourceGroup, "vpc-resource-group", "", "IBM Cloud resource group ID(command: ibmcloud resource groups --id)",
 	)
 	flags.StringVar(
 		&p.NodeImageName, "vpc-node-image-name", "", "Image ID(command: ibmcloud is images)",


### PR DESCRIPTION
- updated the vpc TF flow to consume resource group ID directly
- remove the resource group name lookup from the VPC TF path
- treat `--vpc-resource-group` as a resource group ID
- Use the boskos `resource-group` userdata value directly for VPC deployments
- default boskos acquisition to `vpc-service` when `--target-provider vpc` needs a boskos resource