### PR TITLE
Default to using s1022 machine type for cluster deployment

### DIFF
--- a/kubetest2-tf/data/powervs/instance/variables.tf
+++ b/kubetest2-tf/data/powervs/instance/variables.tf
@@ -47,8 +47,7 @@ variable "network" {
 }
 
 variable "system_type" {
-  description = "Type of system on which the VM should be created - s922/e980"
-  default     = "s922"
+  description = "PowerVS Type of system on which the VM should be created. Options: e1050,e1080,e1180,e980,s1022,s1122,s922"
 }
 
 variable "storage_tier" {

--- a/kubetest2-tf/data/powervs/variables-powervs.tf
+++ b/kubetest2-tf/data/powervs/variables-powervs.tf
@@ -60,8 +60,8 @@ variable "powervs_ssh_key" {
 }
 
 variable "powervs_system_type" {
-  description = "PowerVS Type of system on which the VM should be created e.g s922/e980"
-  default     = "s922"
+  description = "PowerVS Type of system on which the VM should be created. Options: e1050,e1080,e1180,e980,s1022,s1122,s922"
+  default     = "s1022"
 }
 
 variable "powervs_region" {


### PR DESCRIPTION
With the `s922` platform planned to be phased out in the future, `s1022` can be the appropriate default for new
deployments.

Changes: 
1. Change the default value of `powervs_system_type` in `variables-powervs.tf` from `s922` to `s1022`
2. Remove the redundant `default = "s1022"` from the `instance` child module's `system_type` variable

Existing deployments used t on the `s922` default will now use `s1022`.
For overriding the default system type, one can leverage the `TF_VAR_powervs_system_type` variable along with the `kubetest2 tf` command. 


Sample runs:
```
s1022 default type:
 # module.master.ibm_pi_instance.pvminstance[0] will be created
  + resource "ibm_pi_instance" "pvminstance" {
      ...
      + pi_storage_type                = "tier1"
      + pi_sys_type                    = "s1022"
      ...



Overriding the system_type default:
$ export TF_VAR_powervs_system_type="s922"
$ kubetest2-tf  --powervs-image-name CentOS-Stream-10 --powervs-zone osa21 --powervs-region osa....

  # module.master.ibm_pi_instance.pvminstance[0] will be created
  + resource "ibm_pi_instance" "pvminstance" {
  ...
      + pi_storage_type                = "tier1"
      + pi_sys_type                    = "s922"
  ...
```
