### PR TITLE
Set the commit ID as version while building the provisioner binary.

### DIFF
--- a/kubetest2-tf/Makefile
+++ b/kubetest2-tf/Makefile
@@ -28,6 +28,7 @@ REPO_ROOT:=$(shell pwd)
 export REPO_ROOT
 OUT_DIR?=$(REPO_ROOT)/bin
 # record the source commit in the binary, overridable
+COMMIT?=$(shell git rev-parse HEAD)
 INSTALL?=install
 # make install will place binaries here
 # the default path attempts to mimic go install


### PR DESCRIPTION
The `COMMIT` variable was never set with the commit hash of the project, which is necessary to identify the deployer version.
From CI of `pull-provider-ibmcloud-test-infra-kubernetes`
```
make[1]: Entering directory '/home/prow/go/src/github.com/kubernetes-sigs/provider-ibmcloud-test-infra/kubetest2-tf'
Building kubetest2-tf for linux/ppc64le...
GOOS=linux GOARCH=ppc64le go build -trimpath -ldflags="-s -w -buildid= -X=sigs.k8s.io/provider-ibmcloud-test-infra/kubetest2-tf/deployer/deployer.GitTag=" <<-- Missing commit -o /go/bin/kubetest2-tf .
```


Currently, the `metadata.json` has an empty field for `deployer-version`. For eg: [metadata.json](https://storage.googleapis.com/ppc64le-kubernetes/logs/periodic-kubernetes-crio-node-throughput-perf-test-ppc64le/2081016707475836928/artifacts/metadata.json)

```
{
    "deployer-version":"", <-----
    "job-version":"",
    "kubetest-version":"kubetest2 version 558f16b589d15d031595af7d035330b8e87bcaaf",
    "tester-version":"558f16b589d15d031595af7d035330b8e87bcaaf"
}
```

This PR fixes the issue surrounding the same.

With the changes:
```
Building kubetest2-tf for linux/arm64...
GOOS=linux GOARCH=arm64 go build -trimpath -ldflags="-s -w -buildid= -X=sigs.k8s.io/provider-ibmcloud-test-infra/kubetest2-tf/deployer/deployer.GitTag=d7fdce5aa5bae9a89e81977a1afb09f426ff244a" -o /Users/kishenv/github.com/provider-ibmcloud-test-infra/kubetest2-tf/bin/kubetest2-tf
```
